### PR TITLE
Group switcher - disable currently chosen group

### DIFF
--- a/client/app/components/navigation/header-nav.html
+++ b/client/app/components/navigation/header-nav.html
@@ -34,17 +34,20 @@
               <span translate>
                 Change Group:
               </span>
-              <ul class="dropdown-menu scrollable-menu">
-                <li ng-repeat="group in vm.user().groups">
-                  <a href="#" title="{{'Select to change to another Group' | translate}}" ng-click="vm.group_switch(group)">
-                    {{group}}
-                    <span translate ng-if="group === vm.user().group">
-                      (Current Group)
-                    </span>
-                  </a>
-                </li>
-              </ul>
             </a>
+            <ul class="dropdown-menu scrollable-menu">
+              <li ng-repeat="group in vm.user().groups" ng-class="{ disabled: group === vm.user().group }">
+                <a href="#" ng-if="group === vm.user().group" title="{{'Currently Selected Group' | translate}}">
+                  {{group}}
+                  <span translate>
+                    (Current Group)
+                  </span>
+                </a>
+                <a href="#" ng-if="group !== vm.user().group" title="{{'Change to this Group' | translate}}" ng-click="vm.group_switch(group)">
+                  {{group}}
+                </a>
+              </li>
+            </ul>
           </li>
           <li class="disabled" ng-if="! (vm.user().groups.length > 1)">
             <a href="#" title="{{'Current Group' | translate}}">


### PR DESCRIPTION
this changes the group switcher to show the currently chosen group disabled (non-clickable)

also the title was changed from "Select to change to another Group" to "Change to this Group" or "Currently Selected Group"

![grp_other](https://cloud.githubusercontent.com/assets/289743/13077833/2ecfc946-d4b3-11e5-8189-97675d3a8f67.png)
