### PR TITLE
[WIP] Rails 5 fix - depend on an express-http-proxy version that can handle Transfer-Encoding: chunked & IPv6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dateformat": "^1.0.11",
     "debug": "^2.1.3",
     "del": "^2.0.2",
-    "express-http-proxy": "^0.6.0",
     "glob": "^5.0.3",
     "gulp": "^3.8.11",
     "gulp-angular-gettext": "^2.1.0",
@@ -92,6 +91,7 @@
   "dependencies": {
     "body-parser": "^1.12.2",
     "express": "^4.12.3",
+    "express-http-proxy": "git://github.com/himdel/express-http-proxy.git#v0.6.0-transfer-encoding",
     "morgan": "^1.5.2",
     "serve-favicon": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "body-parser": "^1.12.2",
     "express": "^4.12.3",
-    "express-http-proxy": "git://github.com/himdel/express-http-proxy.git#v0.6.0-transfer-encoding",
+    "express-http-proxy": "git://github.com/himdel/express-http-proxy.git#v0.6.0-transfer-encoding-and-ip6",
     "morgan": "^1.5.2",
     "serve-favicon": "^2.2.0"
   },

--- a/server/app.js
+++ b/server/app.js
@@ -14,11 +14,11 @@ var url = require('url');
 
 var environment = process.env.NODE_ENV;
 
-app.use('/api', proxy('127.0.0.1:3000', {
+app.use('/api', proxy('http://[::1]:3000', {
   forwardPath: function(req, res) {
     var path = '/api' + url.parse(req.url).path;
 
-    console.log('PROXY: http://127.0.0.1:3000' + path);
+    console.log('PROXY: http://[::1]:3000' + path);
     return path;
   }
 }));


### PR DESCRIPTION
This fixes the `Parse error` messages (in node console) and the corresponding `net::ERR_EMPTY_RESPONSE` (in browser).

Also change the proxy from `127.0.0.1:3000` to `http://[::1]:3000`, and update `express-http-proxy` to parse that correctly.

Not sure if we want to merge like this, or wait for https://github.com/villadora/express-http-proxy/pull/47 and https://github.com/villadora/express-http-proxy/pull/48.

Also relevant: https://github.com/nodejs/node/issues/5308 - PR https://github.com/nodejs/node/pull/5314