### PR TITLE
Switch from express-http-proxy to node-http-proxy, proxy to [::1]:3000

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ The Self Service UI for the [ManageIQ](http://github.com/ManageIQ/manageiq) proj
 - In the `manageiq-ui-self_service` directory, start the development version of
   the self service UI with `gulp serve-dev`, which will start the UI listening
   on http://localhost:3001, and talking to the REST API at
-  http://localhost:3000.  This command will also open a browser page to
-  http://localhost:3001/self_service/login .
+  http://[::1]:3000.  This command will also open a browser page to
+  http://localhost:3001/self_service/login.  
+  The REST API host can be overriden via a PROXY\_HOST environment variable, for
+  example: `PROXY_HOST=127.0.0.1:3000 gulp serve-dev`.
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dateformat": "^1.0.11",
     "debug": "^2.1.3",
     "del": "^2.0.2",
-    "express-http-proxy": "^0.6.0",
     "glob": "^5.0.3",
     "gulp": "^3.8.11",
     "gulp-angular-gettext": "^2.1.0",
@@ -92,6 +91,7 @@
   "dependencies": {
     "body-parser": "^1.12.2",
     "express": "^4.12.3",
+    "http-proxy": "^1.13.2",
     "morgan": "^1.5.2",
     "serve-favicon": "^2.2.0"
   },

--- a/server/app.js
+++ b/server/app.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var express = require('express');
-var proxy = require('express-http-proxy');
+var httpProxy = require('http-proxy');
 var app = express();
 var router = express.Router();
 var bodyParser = require('body-parser');
@@ -14,14 +14,17 @@ var url = require('url');
 
 var environment = process.env.NODE_ENV;
 
-app.use('/api', proxy('127.0.0.1:3000', {
-  forwardPath: function(req, res) {
-    var path = '/api' + url.parse(req.url).path;
+var PROXY_TARGET = 'http://[::1]:3000/api';
+var proxy = httpProxy.createProxyServer({
+  target: PROXY_TARGET,
+});
 
-    console.log('PROXY: http://127.0.0.1:3000' + path);
-    return path;
-  }
-}));
+app.use('/api', function(req, res) {
+  var path = url.parse(req.url).path;
+
+  console.log('PROXY: ' + PROXY_TARGET + path);
+  proxy.web(req, res);
+});
 
 router.use(favicon(__dirname + '/favicon.ico'));
 router.use(bodyParser.urlencoded({ extended: true }));

--- a/server/app.js
+++ b/server/app.js
@@ -13,8 +13,9 @@ var four0four = require('./utils/404')();
 var url = require('url');
 
 var environment = process.env.NODE_ENV;
+var PROXY_HOST = process.env.PROXY_HOST || '[::1]:3000';
 
-var PROXY_TARGET = 'http://[::1]:3000/api';
+var PROXY_TARGET = 'http://' + PROXY_HOST + '/api';
 var proxy_error_handler = function(req, res) {
   return function(err, data) {
     if (!err)
@@ -68,7 +69,7 @@ switch (environment) {
     router.use(express.static('./tmp'));
     router.use(express.static('./client/assets'));
     var pictureProxy = httpProxy.createProxyServer({
-      target: 'http://[::1]:3000/pictures',
+      target: 'http://' + PROXY_HOST + '/pictures',
     });
     app.use('/pictures', function(req, res) {
       pictureProxy.web(req, res, proxy_error_handler(req, res));

--- a/server/app.js
+++ b/server/app.js
@@ -53,6 +53,12 @@ switch (environment) {
     router.use(express.static('./client/'));
     router.use(express.static('./tmp'));
     router.use(express.static('./client/assets'));
+    var pictureProxy = httpProxy.createProxyServer({
+      target: 'http://[::1]:3000/pictures',
+    });
+    app.use('/pictures', function(req, res) {
+      pictureProxy.web(req, res);
+    });
     app.use(express.static('./'));
     // Any invalid calls for templateUrls are under app/* and should return 404
     router.use('/app/*', function(req, res) {


### PR DESCRIPTION
node-http-proxy development is more active, and it seems it can handle both `Transfer-Encoding: chunked` and proxying to `http://[::1]:3000/api`.

Closes #8

@AparnaKarve can you test it too please?