### PR TITLE
Enable $compile debugging info in DEV mode (+ add a concept of dev-mode)

### DIFF
--- a/client/app/core/config.js
+++ b/client/app/core/config.js
@@ -5,14 +5,22 @@
     .config(configure)
     .run(init);
 
+  var DEVEL_DOMAINS = [
+    'localhost',
+    '127.0.0.1',
+    '[::1]',
+  ];
+
+  var isDevel = window._.includes(DEVEL_DOMAINS, window.location.hostname);
+
   /** @ngInject */
   function configure($logProvider, $compileProvider) {
-    $logProvider.debugEnabled(true);
-    $compileProvider.debugInfoEnabled(false);
+    $logProvider.debugEnabled(isDevel);
+    $compileProvider.debugInfoEnabled(isDevel);
   }
 
   /** @ngInject */
   function init(logger) {
-    logger.showToasts = false;
+    logger.showToasts = isDevel;
   }
 })();


### PR DESCRIPTION
`$compileProvider.debugInfoEnabled(false)` makes the code faster but at
the cost of not being able to inspect scopes and bindings.

Since we don't have any concept of dev/production environments in SSUI
yet (and we can't rely on handling it in the node server since that's not used in
production), adding a simple logic that looks at the current hostname,
checking for `localhost`, `127.0.0.1` and `::1`.