### PR TITLE
Add support for custom buttons with attached dialogs

### DIFF
--- a/client/app/components/custom-button/custom-button.directive.js
+++ b/client/app/components/custom-button/custom-button.directive.js
@@ -26,7 +26,7 @@
 
     function link(scope, element, attrs, vm, transclude) {
       vm.activate();
-      
+
       var win = angular.element($window);
       win.bind('resize', function() { 
         scope.$apply();
@@ -86,7 +86,7 @@
           $state.go('services.custom_button_details', {
             button: button,
             buttonId: button.id,
-            dialog: button.resource_action.dialog,
+            dialogId: button.resource_action.dialog_id,
             serviceId: serviceId,
             serviceTemplateCatalogId: serviceTemplateCatalogId
           });

--- a/client/app/components/custom-button/custom-button.directive.js
+++ b/client/app/components/custom-button/custom-button.directive.js
@@ -11,7 +11,9 @@
       replace: true,
       scope: {
         customActions: '=',
-        actions: '=?'
+        actions: '=?',
+        serviceId: '=',
+        serviceTemplateCatalogId: '='
       },
       link: link,
       templateUrl: 'app/components/custom-button/custom-button.html',
@@ -59,7 +61,7 @@
     }
 
     /** @ngInject */
-    function CustomButtonController(Notifications, CollectionsApi) {
+    function CustomButtonController($state, Notifications, CollectionsApi) {
       var vm = this;
 
       vm.activate = activate;
@@ -76,17 +78,27 @@
         buttonAction.id = temp.split('/')[1];
       }
 
-      function customButtonAction(button) {
+      function customButtonAction(button, serviceId, serviceTemplateCatalogId) {
         var assignedButton = {};
         angular.forEach(vm.actions, actionButtonMapping);
 
-        if (assignedButton.method === 'post') {
-          var data = {action: button.name};
-          CollectionsApi.post(assignedButton.collection, assignedButton.id, {}, data).then(postSuccess, postFailure);
-        } else if (assignedButton.method === 'delete') {
-          CollectionsApi.delete(assignedButton.collection, assignedButton.id, {}).then(deleteSuccess, deleteFailure);
+        if (button.resource_action.dialog_id !== undefined && button.resource_action.dialog_id !== null) {
+          $state.go('services.custom_button_details', {
+            button: button,
+            buttonId: button.id,
+            dialog: button.resource_action.dialog,
+            serviceId: serviceId,
+            serviceTemplateCatalogId: serviceTemplateCatalogId
+          });
         } else {
-          Notifications.error(__('Button action not supported.'));
+          if (assignedButton.method === 'post') {
+            var data = {action: button.name};
+            CollectionsApi.post(assignedButton.collection, assignedButton.id, {}, data).then(postSuccess, postFailure);
+          } else if (assignedButton.method === 'delete') {
+            CollectionsApi.delete(assignedButton.collection, assignedButton.id, {}).then(deleteSuccess, deleteFailure);
+          } else {
+            Notifications.error(__('Button action not supported.'));
+          }
         }
 
         // Private functions

--- a/client/app/components/custom-button/custom-button.html
+++ b/client/app/components/custom-button/custom-button.html
@@ -4,7 +4,7 @@
        <button class="btn btn-default custom-button"
              title="{{button.description}}"
              type="button"
-             ng-click="vm.customButtonAction(button)">
+             ng-click="vm.customButtonAction(button, vm.serviceId, vm.serviceTemplateCatalogId)">
          {{button.name }}
        </button>
     </span>

--- a/client/app/components/custom-button/custom-button.html
+++ b/client/app/components/custom-button/custom-button.html
@@ -11,12 +11,12 @@
     <div class="btn-group dropdown" ng-repeat="buttonGroup in vm.customActions.button_groups">
       <button class="btn btn-default dropdown-toggle custom-button" title="{{buttonGroup.description}}"
             type="button" id="{{buttonGroup.id}}" data-toggle="dropdown">
-        {{ buttonGroup.name}}
+        {{ buttonGroup.name.split('|')[0] }}
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu" aria-labelledby="{{buttonGroup.id}}">
         <li ng-repeat="button in buttonGroup.buttons" role="presentation">
-          <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button)">
+          <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button, vm.serviceId, vm.serviceTemplateCatalogId)">
             {{ button.name }}
           </a>
         </li>
@@ -24,22 +24,23 @@
     </div>
   </span>
   <span ng-if="vm.collapseCustomButtons">
-    <div class="btn-group dropdown custom_actions_menu" ng-if="vm.customActions.buttons.length >=1 || vm.customActions.button_groups >=1">
-      <button class="btn btn-default dropdown-toggle custom-button" title="{{'Actions'|translate}}"
+    <div class="btn-group dropdown custom_actions_menu">
+      <button class="btn btn-default dropdown-toggle custom-button" title="{{'Custom Actions'|translate}}"
             type="button" id="button_custom_actions" data-toggle="dropdown">
-        {{'Actions'|translate}}
+        {{'Custom Actions'|translate}}
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu" aria-labelledby="button_custom_actions">
         <li ng-repeat="button in vm.customActions.buttons" role="presentation">
-          <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button)">
+          <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button, vm.serviceId, vm.serviceTemplateCatalogId)">
             {{ button.name }}
           </a>
         </li>
         <div ng-repeat="buttonGroup in vm.customActions.button_groups">
+          <li class="dropdown-header">{{ buttonGroup.name.split('|')[0] }}</li>
           <li ng-repeat="button in buttonGroup.buttons" role="presentation">
-            <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button)">
-              {{ buttonGroup.name}} - {{ button.name }}
+            <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button, vm.serviceId, vm.serviceTemplateCatalogId)">
+              {{ button.name }}
             </a>
           </li>
         </div>

--- a/client/app/services/dialog-field-refresh.service.js
+++ b/client/app/services/dialog-field-refresh.service.js
@@ -15,7 +15,7 @@
 
     return service;
 
-    function listenForAutoRefreshMessages(allDialogFields, autoRefreshableDialogFields, url, serviceTemplateId) {
+    function listenForAutoRefreshMessages(allDialogFields, autoRefreshableDialogFields, url, resourceId) {
       window.addEventListener('message', function(event) {
         var dialogFieldsToRefresh = autoRefreshableDialogFields.filter(function(fieldName) {
           if (event.data.fieldName !== fieldName) {
@@ -23,11 +23,11 @@
           }
         });
 
-        refreshMultipleDialogFields(allDialogFields, dialogFieldsToRefresh, url, serviceTemplateId);
+        refreshMultipleDialogFields(allDialogFields, dialogFieldsToRefresh, url, resourceId);
       });
     }
 
-    function refreshSingleDialogField(allDialogFields, dialogField, url, serviceTemplateId) {
+    function refreshSingleDialogField(allDialogFields, dialogField, url, resourceId) {
       function refreshSuccess(result) {
         var resultObj = result.result[dialogField.name];
 
@@ -39,7 +39,7 @@
         Notifications.error('There was an error refreshing this dialog: ' + result);
       }
 
-      fetchDialogFieldInfo(allDialogFields, [dialogField.name], url, serviceTemplateId, refreshSuccess, refreshFailure);
+      fetchDialogFieldInfo(allDialogFields, [dialogField.name], url, resourceId, refreshSuccess, refreshFailure);
     }
 
     function setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields) {
@@ -77,7 +77,7 @@
 
     // Private
 
-    function refreshMultipleDialogFields(allDialogFields, fieldNamesToRefresh, url, serviceTemplateId) {
+    function refreshMultipleDialogFields(allDialogFields, fieldNamesToRefresh, url, resourceId) {
       function refreshSuccess(result) {
         angular.forEach(allDialogFields, function(dialogField) {
           if (fieldNamesToRefresh.indexOf(dialogField.name) > -1) {
@@ -91,7 +91,7 @@
         Notifications.error('There was an error automatically refreshing dialogs' + result);
       }
 
-      fetchDialogFieldInfo(allDialogFields, fieldNamesToRefresh, url, serviceTemplateId, refreshSuccess, refreshFailure);
+      fetchDialogFieldInfo(allDialogFields, fieldNamesToRefresh, url, resourceId, refreshSuccess, refreshFailure);
     }
 
     function updateAttributesForDialogField(dialogField, newDialogField) {
@@ -120,10 +120,10 @@
       }
     }
 
-    function fetchDialogFieldInfo(allDialogFields, dialogFieldsToFetch, url, serviceTemplateId, successCallback, failureCallback) {
+    function fetchDialogFieldInfo(allDialogFields, dialogFieldsToFetch, url, resourceId, successCallback, failureCallback) {
       CollectionsApi.post(
         url,
-        serviceTemplateId,
+        resourceId,
         {},
         JSON.stringify({
           action: 'refresh_dialog_fields',

--- a/client/app/services/dialog-field-refresh.service.js
+++ b/client/app/services/dialog-field-refresh.service.js
@@ -9,6 +9,7 @@
     var service = {
       listenForAutoRefreshMessages: listenForAutoRefreshMessages,
       refreshSingleDialogField: refreshSingleDialogField,
+      setupDialogData: setupDialogData,
       triggerAutoRefresh: triggerAutoRefresh
     };
 
@@ -39,6 +40,33 @@
       }
 
       fetchDialogFieldInfo(allDialogFields, [dialogField.name], url, serviceTemplateId, refreshSuccess, refreshFailure);
+    }
+
+    function setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields) {
+      angular.forEach(dialogs, function(dialog) {
+        angular.forEach(dialog.dialog_tabs, function(dialogTab) {
+          angular.forEach(dialogTab.dialog_groups, function(dialogGroup) {
+            angular.forEach(dialogGroup.dialog_fields, function(dialogField) {
+              allDialogFields.push(dialogField);
+              if (dialogField.default_value === '' && dialogField.values !== '') {
+                dialogField.default_value = dialogField.values;
+              }
+
+              if (typeof (dialogField.values) === 'object' && dialogField.default_value === undefined) {
+                dialogField.default_value = String(dialogField.values[0][0]);
+              }
+
+              dialogField.triggerAutoRefresh = function() {
+                triggerAutoRefresh(dialogField);
+              };
+
+              if (dialogField.auto_refresh === true) {
+                autoRefreshableDialogFields.push(dialogField.name);
+              }
+            });
+          });
+        });
+      });
     }
 
     function triggerAutoRefresh(dialogField) {

--- a/client/app/services/dialog-field-refresh.service.spec.js
+++ b/client/app/services/dialog-field-refresh.service.spec.js
@@ -252,6 +252,76 @@ describe('app.services.DialogFieldRefresh', function() {
     });
   });
 
+  describe('#setupDialogData', function() {
+    var allDialogFields;
+    var autoRefreshableDialogFields;
+
+    beforeEach(function() {
+      allDialogFields = [];
+      autoRefreshableDialogFields = [];
+    });
+
+    describe('when the dialog field default value is blank but the values are not', function() {
+      var dialogField = {name: 'dialog1', values: 'test_value', default_value: ''};
+      var dialogs = [{dialog_tabs: [{dialog_groups: [{dialog_fields: [dialogField]}]}]}];
+
+      it('pushes the dialog fields into the all dialog fields array', function() {
+        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+        expect(allDialogFields.length).to.equal(1);
+      });
+
+      it('assigns the default value', function() {
+        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+        expect(dialogField.default_value).to.equal('test_value');
+      });
+
+      it('sets up the triggering of auto refresh', function() {
+        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+        expect(dialogField).to.respondTo('triggerAutoRefresh');
+      });
+    });
+
+    describe('when the dialog field has an object for values but no default value', function() {
+      var dialogField = {name: 'dialog1', values: [[1, 'one']]};
+      var dialogs = [{dialog_tabs: [{dialog_groups: [{dialog_fields: [dialogField]}]}]}];
+
+      it('pushes the dialog field into the all dialog fields array', function() {
+        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+        expect(allDialogFields.length).to.equal(1);
+      });
+
+      it('assigns the default value', function() {
+        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+        expect(dialogField.default_value).to.equal('1');
+      });
+
+      it('sets up the triggering of auto refresh', function() {
+        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+        expect(dialogField).to.respondTo('triggerAutoRefresh');
+      });
+    });
+
+    describe('when the dialog field is auto refreshable', function() {
+      var dialogField = {auto_refresh: true, name: 'dialog1'};
+      var dialogs = [{dialog_tabs: [{dialog_groups: [{dialog_fields: [dialogField]}]}]}];
+
+      it('pushes the dialog field into the all dialog fields array', function() {
+        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+        expect(allDialogFields.length).to.equal(1);
+      });
+
+      it('sets up the triggering of auto refresh', function() {
+        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+        expect(dialogField).to.respondTo('triggerAutoRefresh');
+      });
+
+      it('pushes the dialog field name into the auto refreshable array', function() {
+        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+        expect(autoRefreshableDialogFields[0]).to.equal('dialog1');
+      });
+    });
+  });
+
   describe('#triggerAutoRefresh', function() {
     var postMessageSpy;
     var dialogField = {};

--- a/client/app/states/marketplace/details/details.state.js
+++ b/client/app/states/marketplace/details/details.state.js
@@ -55,30 +55,7 @@
     var autoRefreshableDialogFields = [];
     var allDialogFields = [];
 
-    angular.forEach(vm.dialogs, function(dialog) {
-      angular.forEach(dialog.dialog_tabs, function(dialogTab) {
-        angular.forEach(dialogTab.dialog_groups, function(dialogGroup) {
-          angular.forEach(dialogGroup.dialog_fields, function(dialogField) {
-            allDialogFields.push(dialogField);
-            if (dialogField.default_value === '' && dialogField.values !== '') {
-              dialogField.default_value = dialogField.values;
-            }
-
-            if (typeof (dialogField.values) === 'object' && dialogField.default_value === undefined) {
-              dialogField.default_value = String(dialogField.values[0][0]);
-            }
-
-            dialogField.triggerAutoRefresh = function() {
-              DialogFieldRefresh.triggerAutoRefresh(dialogField);
-            };
-
-            if (dialogField.auto_refresh === true) {
-              autoRefreshableDialogFields.push(dialogField.name);
-            }
-          });
-        });
-      });
-    });
+    DialogFieldRefresh.setupDialogData(vm.dialogs, allDialogFields, autoRefreshableDialogFields);
 
     var dialogUrl = 'service_catalogs/' + serviceTemplate.service_template_catalog_id + '/service_templates';
 

--- a/client/app/states/services/custom_button_details/custom_button_details.html
+++ b/client/app/states/services/custom_button_details/custom_button_details.html
@@ -1,7 +1,13 @@
 <ol class="breadcrumb">
   <li>
-    <a ui-sref="^"> <span class="fa fa-angle-double-left"/>&nbsp;{{'Back to Service Catalog'|translate}}</a>
+    <a ui-sref="^">{{'Back to Service Catalog'|translate}}</a>
   </li>
+  <li>
+    <a ui-sref="services.details({serviceId: vm.serviceId})">
+      {{'Back to Service'|translate}}: {{ ::vm.service.name }}
+    </a>
+  </li>
+  <li class="active"> <strong translate>Custom Button:</strong> {{ ::vm.button.name }} </li>
 </ol>
 
 <pf-notification-list></pf-notification-list>

--- a/client/app/states/services/custom_button_details/custom_button_details.html
+++ b/client/app/states/services/custom_button_details/custom_button_details.html
@@ -1,0 +1,35 @@
+<ol class="breadcrumb">
+  <li>
+    <a ui-sref="^"> <span class="fa fa-angle-double-left"/>&nbsp;{{'Back to Service Catalog'|translate}}</a>
+  </li>
+</ol>
+
+<pf-notification-list></pf-notification-list>
+
+<div class="panel panel-default ss-details-panel">
+  <div class="panel-body">
+    <section>
+    <div class="col-md-12 ss-details-header ss-marketplace-details-header">
+      <div class="row">
+        <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4 ss-details-header__actions">
+          <button type="button" class="btn btn-primary" ng-click="vm.submitCustomButton()" translate>Submit Request</button>
+        </div>
+      </div>
+    </div>
+    </section>
+  </div>
+</div>
+
+<div class="panel panel-default ss-details-panel ss-marketplace-details-form">
+  <div class="panel-body">
+    <section>
+    <div class="col-md-12">
+      <div class="row">
+        <div ng-repeat="dialog in ::vm.dialogs">
+          <dialog-content dialog="dialog"></dialog-content>
+        </div>
+      </div>
+    </div>
+    </section>
+  </div>
+</div>

--- a/client/app/states/services/custom_button_details/custom_button_details.state.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.js
@@ -1,0 +1,99 @@
+(function() {
+  'use strict';
+
+  angular.module('app.states')
+    .run(appRun);
+
+  /** @ngInject */
+  function appRun(routerHelper) {
+    routerHelper.configureStates(getStates());
+  }
+
+  function getStates() {
+    return {
+      'services.custom_button_details': {
+        url: '/:serviceId/custom_button_details/:buttonId',
+        templateUrl: 'app/states/services/custom_button_details/custom_button_details.html',
+        controller: StateController,
+        controllerAs: 'vm',
+        title: N_('Service Custom Button Details'),
+        params: {dialog: null, button: null, serviceTemplateCatalogId: null},
+      }
+    };
+  }
+
+  /** @ngInject */
+  function StateController($state, $stateParams, CollectionsApi, Notifications, DialogFieldRefresh) {
+    var vm = this;
+    vm.title = __('Custom button action');
+    vm.dialogs = [$stateParams.dialog];
+    vm.submitCustomButton = submitCustomButton;
+
+    var autoRefreshableDialogFields = [];
+    var allDialogFields = [];
+
+    angular.forEach(vm.dialogs, function(dialog) {
+      angular.forEach(dialog.dialog_tabs, function(dialogTab) {
+        angular.forEach(dialogTab.dialog_groups, function(dialogGroup) {
+          angular.forEach(dialogGroup.dialog_fields, function(dialogField) {
+            allDialogFields.push(dialogField);
+            if (dialogField.default_value === '' && dialogField.values !== '') {
+              dialogField.default_value = dialogField.values;
+            }
+
+            if (typeof (dialogField.values) === 'object' && dialogField.default_value === undefined) {
+              dialogField.default_value = String(dialogField.values[0][0]);
+            }
+
+            dialogField.triggerAutoRefresh = function() {
+              DialogFieldRefresh.triggerAutoRefresh(dialogField);
+            };
+
+            if (dialogField.auto_refresh === true) {
+              autoRefreshableDialogFields.push(dialogField.name);
+            }
+          });
+        });
+      });
+    });
+
+    var dialogUrl = 'service_catalogs/' + $stateParams.serviceTemplateCatalogId + '/service_templates';
+
+    angular.forEach(allDialogFields, function(dialogField) {
+      dialogField.refreshSingleDialogField = function() {
+        DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialogField, dialogUrl, $stateParams.button.applies_to_id);
+      };
+    });
+
+    DialogFieldRefresh.listenForAutoRefreshMessages(
+      allDialogFields,
+      autoRefreshableDialogFields,
+      dialogUrl,
+      $stateParams.button.applies_to_id
+    );
+
+    function submitCustomButton() {
+      var dialogFieldData = {};
+
+      angular.forEach(allDialogFields, function(dialogField) {
+        dialogFieldData[dialogField.name] = dialogField.default_value;
+      });
+
+      CollectionsApi.post(
+        'services',
+        $stateParams.serviceId,
+        {},
+        JSON.stringify({action: $stateParams.button.name, resource: dialogFieldData})
+      ).then(submitSuccess, submitFailure);
+
+      function submitSuccess(result) {
+        Notifications.success(result.message);
+        $state.go('services.details', {serviceId: $stateParams.serviceId});
+      }
+
+      function submitFailure(result) {
+        Notifications.error(__('There was an error submitting this request: ') + result);
+      }
+    }
+  }
+})();

--- a/client/app/states/services/custom_button_details/custom_button_details.state.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.js
@@ -55,11 +55,11 @@
 
     DialogFieldRefresh.setupDialogData(vm.dialogs, allDialogFields, autoRefreshableDialogFields);
 
-    var dialogUrl = 'service_catalogs/' + $stateParams.serviceTemplateCatalogId + '/service_templates';
+    var dialogUrl = 'service_dialogs/';
 
     angular.forEach(allDialogFields, function(dialogField) {
       dialogField.refreshSingleDialogField = function() {
-        DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialogField, dialogUrl, $stateParams.button.applies_to_id);
+        DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialogField, dialogUrl, dialog.id);
       };
     });
 
@@ -67,7 +67,7 @@
       allDialogFields,
       autoRefreshableDialogFields,
       dialogUrl,
-      $stateParams.button.applies_to_id
+      dialog.id
     );
 
     function submitCustomButton() {

--- a/client/app/states/services/custom_button_details/custom_button_details.state.spec.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.spec.js
@@ -1,0 +1,100 @@
+/* jshint -W117, -W030 */
+describe('services.custom_button_details', function() {
+  beforeEach(function() {
+    module('app.states', 'app.config', 'gettext', bard.fakeToastr);
+  });
+
+  describe('controller', function() {
+    var collectionsApiSpy;
+    var controller;
+    var notificationsErrorSpy;
+    var notificationsSuccessSpy;
+    var dialog = {
+      dialog_tabs: [{
+        dialog_groups: [{
+          dialog_fields: [{
+            name: 'dialogField1',
+            default_value: '1'
+          }, {
+            name: 'dialogField2',
+            default_value: '2'
+          }]
+        }]
+      }]
+    };
+    var button = {
+      name: 'buttonName',
+      applies_to_id: 456
+    };
+
+    beforeEach(function() {
+      bard.inject('$controller', '$log', '$state', '$rootScope', 'CollectionsApi', 'Notifications');
+
+      controller = $controller($state.get('services.custom_button_details').controller, {
+        dialog: dialog,
+        button: button,
+        serviceId: 123,
+        serviceTemplateCatalogId: 321
+      });
+      $rootScope.$apply();
+    });
+
+    describe('controller initialization', function() {
+      it('is created successfully', function() {
+        expect(controller).to.be.defined;
+      });
+    });
+
+    describe('controller#submitCustomButton', function() {
+      describe('when the API call is successful', function() {
+        beforeEach(function() {
+          var successResponse = {
+            message: 'Great Success!'
+          };
+
+          collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse));
+          notificationsSuccessSpy = sinon.spy(Notifications, 'success');
+        });
+
+        it('POSTs to the services API', function() {
+          controller.submitCustomButton();
+          expect(collectionsApiSpy).to.have.been.calledWith(
+            'services',
+            123,
+            {},
+            '{"action":"buttonName","resource":{"dialogField1":"1","dialogField2":"2"}}'
+          );
+        });
+
+        it('makes a notification success call', function(done) {
+          controller.submitCustomButton();
+          done();
+          expect(notificationsSuccessSpy).to.have.been.calledWith('Great Success!');
+        });
+
+        it('goes to the service details', function(done) {
+          controller.submitCustomButton();
+          done();
+          expect($state.is('services.details')).to.be.true;
+        });
+      });
+
+      describe('when the API call fails', function() {
+        beforeEach(function() {
+          var errorResponse = 'oopsies';
+
+          collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.reject(errorResponse));
+          notificationsErrorSpy = sinon.spy(Notifications, 'error');
+        });
+
+        it('makes a notification error call', function(done) {
+          controller.submitCustomButton();
+          done();
+          expect(notificationsErrorSpy).to.have.been.calledWith(
+            'There was an error submitting this request: oopsies'
+          );
+        });
+      });
+    });
+  });
+});

--- a/client/app/states/services/custom_button_details/custom_button_details.state.spec.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.spec.js
@@ -28,13 +28,15 @@ describe('services.custom_button_details', function() {
     };
 
     beforeEach(function() {
-      bard.inject('$controller', '$log', '$state', '$rootScope', 'CollectionsApi', 'Notifications');
+      bard.inject('$controller', '$log', '$state', '$stateParams', '$rootScope', 'CollectionsApi', 'Notifications');
 
       controller = $controller($state.get('services.custom_button_details').controller, {
-        dialog: dialog,
-        button: button,
-        serviceId: 123,
-        serviceTemplateCatalogId: 321
+        $stateParams: {
+          dialog: dialog,
+          button: button,
+          serviceId: 123,
+          serviceTemplateCatalogId: 321
+        }
       });
       $rootScope.$apply();
     });

--- a/client/app/states/services/custom_button_details/custom_button_details.state.spec.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.spec.js
@@ -31,8 +31,10 @@ describe('services.custom_button_details', function() {
       bard.inject('$controller', '$log', '$state', '$stateParams', '$rootScope', 'CollectionsApi', 'Notifications');
 
       controller = $controller($state.get('services.custom_button_details').controller, {
+        dialog: {content: [dialog]},
+        service: {},
         $stateParams: {
-          dialog: dialog,
+          dialogId: 213,
           button: button,
           serviceId: 123,
           serviceTemplateCatalogId: 321

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -28,8 +28,14 @@
             </div>
             <div class="col-lg-7 col-md-6 col-sm-6 col-xs-6 ss-details-header__actions">
               <div class="ss-details-header__actions__inner">
-              <custom-button custom-actions="vm.service.custom_actions" actions="vm.service.actions"></custom-button>
-              <button class="btn btn-default" type="button" tooltip="{{'Permanently delete the service'|translate}}" tooltip-placement="bottom" ng-show="vm.showRemoveService"
+              <custom-button
+                service-template-catalog-id="vm.service.service_template.service_template_catalog_id"
+                service-id="vm.service.id"
+                custom-actions="vm.service.custom_actions"
+                actions="vm.service.actions">
+              </custom-button>
+              <button class="btn btn-default" type="button" tooltip="{{'Permanently delete the service'|translate}}" tooltip-placement="bottom"
+                    ng-show="vm.showRemoveService"
                     confirmation
                     confirmation-if="true"
                     confirmation-title="{{'Remove Service'|translate}}"

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -40,7 +40,8 @@
       'aggregate_all_vm_memory_on_disk',
       'actions',
       'custom_actions',
-      'provision_dialog'
+      'provision_dialog',
+      'service_template'
     ];
     var options = {attributes: requestAttributes};
 

--- a/client/index.html
+++ b/client/index.html
@@ -148,6 +148,7 @@
   <script src="/client/app/states/requests/details/details.state.js"></script>
   <script src="/client/app/states/requests/list/list.state.js"></script>
   <script src="/client/app/states/requests/requests.state.js"></script>
+  <script src="/client/app/states/services/custom_button_details/custom_button_details.state.js"></script>
   <script src="/client/app/states/services/details/details.state.js"></script>
   <script src="/client/app/states/services/list/list.state.js"></script>
   <script src="/client/app/states/services/reconfigure/reconfigure.state.js"></script>


### PR DESCRIPTION
There is currently an issue where when a required field is not filled in or given, the API call still returns a 200 success, and so the SSUI returns back to the service with a message saying "Success! X field is required".

While testing this, an issue was also discovered where while ordering a service through a service template custom dialogs do not honor the required fields and allow submissions with "incomplete" forms. See git issue: #14

~~I'm also having a lot of issues with specs, so I figured I'd throw this WIP out there to see if travis works any better.~~