### PR TITLE
Fix broken redirect to /login when user is not logged in

### DIFF
--- a/client/app/blocks/router/router-helper.provider.js
+++ b/client/app/blocks/router/router-helper.provider.js
@@ -90,7 +90,7 @@
         msg = 'Error routing to ' + destination + '. '
           + (error.data || '') + '. <br/>' + (error.statusText || '')
           + ': ' + (error.status || '');
-        logger.warning(msg, [toState]);
+        logger.warning(msg, [toState, error]);
         $location.path('/');
       }
 

--- a/client/app/config/authorization.config.js
+++ b/client/app/config/authorization.config.js
@@ -86,6 +86,8 @@
               $state.go('login');
             }
           });
+
+        return;
       }
 
       event.preventDefault();

--- a/client/app/config/authorization.config.js
+++ b/client/app/config/authorization.config.js
@@ -89,6 +89,7 @@
       }
 
       event.preventDefault();
+      $state.transitionTo('login');
     }
 
     function changeError(event, toState, toParams, fromState, fromParams, error) {

--- a/client/app/config/authorization.config.js
+++ b/client/app/config/authorization.config.js
@@ -87,6 +87,8 @@
             }
           });
 
+        event.preventDefault();
+
         return;
       }
 


### PR DESCRIPTION
reintroduce the login transition removed in e3d67eb21

@AparnaKarve this shouldn't break anything else, right?


Without this, going to /self_service without being logged in (but with a previous session's token saved), you get stuck on the loading screen. (Going directly to /login works either way.)