### PR TITLE
SDUI: Hiding Blueprints nav. tab by default

### DIFF
--- a/client/app/services/session.service.js
+++ b/client/app/services/session.service.js
@@ -86,7 +86,8 @@
         dashboard:   {show: entitledForDashboard(productFeatures)},
         services:    {show: entitledForServices(productFeatures)},
         requests:    {show: entitledForRequests(productFeatures)},
-        marketplace: {show: entitledForServiceCatalogs(productFeatures)}
+        marketplace: {show: entitledForServiceCatalogs(productFeatures)},
+        blueprints:  {show: false}
       };
       model.navFeatures = features;
 


### PR DESCRIPTION
- To display the "Blueprints" nav tab, change to "blueprints: {show:true}"