### PR TITLE
Fix extraneous auto-refresh API calls

### DIFF
--- a/client/app/services/dialog-field-refresh.service.js
+++ b/client/app/services/dialog-field-refresh.service.js
@@ -1,3 +1,4 @@
+/* jshint -W117 */
 (function() {
   'use strict';
 
@@ -16,15 +17,20 @@
     return service;
 
     function listenForAutoRefreshMessages(allDialogFields, autoRefreshableDialogFields, url, resourceId) {
-      window.addEventListener('message', function(event) {
+      var listenerFunction = function(event) {
         var dialogFieldsToRefresh = autoRefreshableDialogFields.filter(function(fieldName) {
-          if (event.data.fieldName !== fieldName) {
+          if (event.originalEvent.data.fieldName !== fieldName) {
             return fieldName;
           }
         });
 
-        refreshMultipleDialogFields(allDialogFields, dialogFieldsToRefresh, url, resourceId);
-      });
+        if (dialogFieldsToRefresh !== []) {
+          refreshMultipleDialogFields(allDialogFields, dialogFieldsToRefresh, url, resourceId);
+        }
+      };
+
+      $(window).off('message'); // Unbind all previous message listeners
+      $(window).on('message', listenerFunction);
     }
 
     function refreshSingleDialogField(allDialogFields, dialogField, url, resourceId) {

--- a/client/app/services/dialog-field-refresh.service.spec.js
+++ b/client/app/services/dialog-field-refresh.service.spec.js
@@ -9,16 +9,15 @@ describe('app.services.DialogFieldRefresh', function() {
     var eventListenerSpy;
 
     beforeEach(function() {
-      eventListenerSpy = sinon.spy(window, 'addEventListener');
-    });
-
-    afterEach(function() {
-      window.addEventListener.restore();
+      $ = sinon.stub();
+      eventListenerSpy = sinon.stub({on: function() {}, off: function() {}});
+      $.withArgs(window).returns(eventListenerSpy);
     });
 
     it('sets up a listener on the window', function() {
       DialogFieldRefresh.listenForAutoRefreshMessages([], [], 'the_url', '123');
-      expect(eventListenerSpy).to.have.been.calledWith('message');
+      expect(eventListenerSpy.off).to.have.been.calledWith('message');
+      expect(eventListenerSpy.on).to.have.been.calledWith('message');
     });
   });
 


### PR DESCRIPTION
This will unbind and rebind window listeners so they don't accumulate and cause strange behavior.

This also fixes an issue where if none of the dialogs respond to an auto refresh, the API call was made with no dialogs to refresh, which caused issues. In this instance, the API call doesn't even need to be made so that saves a hit.

I think this may be related to quite a few BZs, but I don't think this fixes the whole problem. There appears to be another issue on the manageiq side involving the API and the data that is being returned.

https://bugzilla.redhat.com/show_bug.cgi?id=1303169