### PR TITLE
Remove NPM warnings from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "Michael Stack",
     "Allen Wight"
   ],
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ManageIQ/manageiq-ui-self_service.git"
+  },
   "scripts": {
     "init": "npm install",
     "install": "bower install -F",


### PR DESCRIPTION
This removes the following warnings when doing `npm install`

```
npm WARN package.json manageiq-ui-self_service@0.0.1 No repository field.
npm WARN package.json manageiq-ui-self_service@0.0.1 license should be a valid SPDX license expression
```