### PR TITLE
Console support under My Services

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -25,9 +25,9 @@
   "strict"        : false,    // true: Requires all functions run in ES5 Strict Mode
   "maxparams"     : 10,       // {int} Max number of formal params allowed per function
   "maxdepth"      : 4,        // {int} Max depth of nested blocks (within functions)
-  "maxstatements" : 30,       // {int} Max number statements per function
-  "maxcomplexity" : 10,       // {int} Max cyclomatic complexity per function
-  "maxlen"        : 140,      // {int} Max number of characters per line
+  "maxstatements" : 32,       // {int} Max number statements per function
+  "maxcomplexity" : 12,       // {int} Max cyclomatic complexity per function
+  "maxlen"        : 160,      // {int} Max number of characters per line
 
   // Relaxing
   "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)

--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,8 @@
     "patternfly": "~2.3.0",
     "sprintf": "~1.0.3",
     "toastr": "~2.1.1",
-    "no-vnc": "~0.5.1"
+    "no-vnc": "~0.5.1",
+    "spice-html5-bower": "^0.1.6"
   },
   "overrides": {
     "patternfly": {
@@ -64,6 +65,9 @@
       ]
     },
     "no-vnc": {
+      "main": []
+    },
+    "spice-html5-bower": {
       "main": []
     }
   }

--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,8 @@
     "ngstorage": "~0.3.10",
     "patternfly": "~2.3.0",
     "sprintf": "~1.0.3",
-    "toastr": "~2.1.1"
+    "toastr": "~2.1.1",
+    "no-vnc": "~0.5.1"
   },
   "overrides": {
     "patternfly": {
@@ -61,6 +62,9 @@
         "build/ngprogress.js",
         "ngProgress.css"
       ]
+    },
+    "no-vnc": {
+      "main": []
     }
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "sprintf": "~1.0.3",
     "toastr": "~2.1.1",
     "no-vnc": "~0.5.1",
-    "spice-html5-bower": "^0.1.6"
+    "spice-html5-bower": "v0.1.6.1"
   },
   "overrides": {
     "patternfly": {

--- a/client/app/resources/collections-api.factory.js
+++ b/client/app/resources/collections-api.factory.js
@@ -64,6 +64,13 @@
         params.push('attributes=' + options.attributes);
       }
 
+      if (options.decorators) {
+        if (angular.isArray(options.decorators)) {
+          options.decorators = options.decorators.join(',');
+        }
+        params.push('decorators=' + options.decorators);
+      }
+
       if (options.filter) {
         angular.forEach(options.filter, function(filter) {
           params.push('filter[]=' + filter);

--- a/client/app/services/consoles.service.js
+++ b/client/app/services/consoles.service.js
@@ -1,0 +1,112 @@
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('Consoles', ConsolesFactory);
+
+  /** @ngInject */
+  function ConsolesFactory(CollectionsApi, $http, $timeout, logger, $location, Notifications) {
+    var service = {
+      open: openConsole,
+    };
+
+    return service;
+
+    function openConsole(vmId) {
+      CollectionsApi.post('vms', vmId, {}, {
+        action: 'request_console',
+        resource: { protocol: "html5" },
+      })
+      .then(consoleResponse)
+      .catch(consoleError);
+    }
+
+    function consoleResponse(response) {
+      if (!response.success) {
+        // for some reason failure is 200 + success=false here, so throwing the message to use the same error handler
+        throw response.message;
+      }
+
+      Notifications.info(__("Waiting for the console to become ready"));
+      logger.info(__("Waiting for the console to become ready:"), response.message);
+
+      consoleWatch(response.task_href + '?attributes=task_results');
+    }
+
+    function consoleError(error) {
+      Notifications.error(__("There was an error opening the console"));
+      logger.error(__("There was an error opening the console:"), error);
+    }
+
+    // try to get the task results every second, until Finished (or error)
+    function consoleWatch(url) {
+      $timeout(function() {
+        $http.get(url)
+        .then(function(response) {
+          var task = response.data;
+
+          if ((task.state === 'Finished') && (task.status === 'Ok')) {
+            // success
+            consoleOpen(task.task_results);
+          } else if ((task.state === 'Queued') && (task.status === 'Ok')) {
+            // waiting
+            consoleWatch(url);
+          } else {
+            // failure
+            throw task.message;
+          }
+        })
+        .catch(consoleError);
+      }, 1000);
+    }
+
+    function consoleOpen(results) {
+      switch (results.proto) {
+        case 'spice':
+          openSpice(results);
+          break;
+        case 'vnc':
+          openVnc(results);
+          break;
+        case 'remote':
+          openRemote(results);
+          break;
+        default:
+          Notifications.error(__("Unsupported console protocol returned"));
+          logger.error(__("Unsupported console protocol returned:"), results.proto);
+      }
+    }
+
+    function openSpice(results) {
+      var url = '/bower_components/spice-html5-bower/spiceHTML5/spice_auto.html' +
+        '?host=' + $location.host() +
+        '&port=' + $location.port() +
+        '&path=' + results.url +
+        '&password=' + results.secret;
+
+      // encrypt is divined automagically in spice_auto
+
+      window.open(url);
+    }
+
+    function openVnc(results) {
+      var url = '/bower_components/no-vnc/vnc_auto.html' +
+        '?host=' + $location.host() +
+        '&port=' + $location.port() +
+        '&path=' + results.url +
+        '&password=' + results.secret +
+        '&true_color=1';
+
+      if ($location.protocol() === 'https') {
+        url += '&encrypt=1';
+      }
+
+      window.open(url);
+    }
+
+    function openRemote(results) {
+      // openstack
+      window.open(results.remote_url);
+    }
+  }
+})();

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -196,7 +196,7 @@
             </div>
             <div class="col-lg-1 col-md-1 hidden-sm hidden-xs">
               <span class="no-wrap">
-                <button class="btn btn-default" ng-if="item.power_state == 'on'" tooltip="{{'Open a HTML5 console for this VM'|translate}}" tooltip-placement="right">
+                <button class="btn btn-default" ng-if="item['supports_console?'] && item.power_state == 'on'" tooltip="{{'Open a HTML5 console for this VM'|translate}}" tooltip-placement="right">
                   <i class="fa fa-html5 fa-lg"></i>
                 </button>
               </span>

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -186,12 +186,19 @@
                 <strong tooltip="{{'The last heartbeat received from the instances'|translate}}" tooltip-placement="bottom" translate>Last Scan</strong>&nbsp;{{ item.last_scan_on | date:'medium' }}
               </span>
             </div>
-            <div class="col-lg-2 col-md-3 hidden-sm hidden-xs">
+            <div class="col-lg-1 col-md-2 hidden-sm hidden-xs">
               <span class="no-wrap">
                 <i class="fa pficon fa-power-off" ng-if="item.power_state == 'off'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
                 <i class="pficon pficon-ok" ng-if="item.power_state == 'on'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
                 <i class="fa pficon fa-pause" ng-if="item.power_state == 'suspended'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
                 {{ item.power_state }}
+              </span>
+            </div>
+            <div class="col-lg-1 col-md-1 hidden-sm hidden-xs">
+              <span class="no-wrap">
+                <button class="btn btn-default" ng-if="item.power_state == 'on'" tooltip="{{'Open a HTML5 console for this VM'|translate}}" tooltip-placement="right">
+                  <i class="fa fa-html5 fa-lg"></i>
+                </button>
               </span>
             </div>
           </div>

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -196,7 +196,7 @@
             </div>
             <div class="col-lg-1 col-md-1 hidden-sm hidden-xs">
               <span class="no-wrap">
-                <button class="btn btn-default" ng-if="item['supports_console?'] && item.power_state == 'on'" tooltip="{{'Open a HTML5 console for this VM'|translate}}" tooltip-placement="right">
+                <button class="btn btn-default open-console-button" ng-if="item['supports_console?'] && item.power_state == 'on'" tooltip="{{'Open a HTML5 console for this VM'|translate}}" tooltip-placement="right">
                   <i class="fa fa-html5 fa-lg"></i>
                 </button>
               </span>
@@ -214,4 +214,3 @@
     </div>
   </div>
 </div>
-

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -188,8 +188,13 @@
       }
 
       function openSpice(results) {
-        // TODO
-        console.log('TODO spice', results);
+        var url = '/bower_components/spice-html5-bower/spiceHTML5/spice_auto.html' +
+          '?host=localhost' + // TODO not always
+          '&port=3000' +  // TODO huh.. either 3000 or need to change server/app.js to proxy ws as well
+          '&path=' + results.url +
+          '&password=' + results.secret;  // or token?
+
+        window.open(url);
       }
 
       function openVnc(results) {

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -174,7 +174,18 @@
       }
 
       function consoleOpen(results) {
+        // FIXME: may want to support results.remote_url as well (but haven't seen one in the wild yet)
+
         console.log('consoleOpen', results);
+        /* novnc:
+
+           /bower_components/no-vnc/vnc_auto.html
+             ?host=localhost
+             &port=3000
+             &true_color=1
+             &path=ws/console/ea713e07ffe1ea9a029bf97202cb9798
+             (&encrypt=1 if SSL)
+         */
       }
     }
 

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -31,7 +31,6 @@
       'picture.image_href',
       'evm_owner.name',
       'miq_group.description',
-      'vms',
       'aggregate_all_vm_cpus',
       'aggregate_all_vm_memory',
       'aggregate_all_vm_disk_count',
@@ -43,7 +42,11 @@
       'provision_dialog',
       'service_template'
     ];
-    var options = {attributes: requestAttributes};
+    var options = {
+      attributes: requestAttributes,
+      decorators: [ 'vms.supports_console?' ],
+      expand: 'vms',
+    };
 
     return CollectionsApi.get('services', $stateParams.serviceId, options);
   }

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -52,7 +52,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, Notifications) {
+  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, Notifications, jQuery) {
     var vm = this;
 
     vm.showRemoveService = $state.actionFeatures.service_delete.show;
@@ -72,6 +72,7 @@
     vm.retireServiceLater = retireServiceLater;
     vm.ownershipServiceModal = ownershipServiceModal;
     vm.reconfigureService = reconfigureService;
+    vm.openConsole = openConsole;
 
     var actions = vm.service.actions;
     if (actions !== undefined) {
@@ -88,7 +89,8 @@
 
     vm.listConfig = {
       selectItems: false,
-      showSelectBox: false
+      showSelectBox: false,
+      onClick: maybeOpenConsole,
     };
 
     activate();
@@ -108,6 +110,26 @@
       function removeFailure(data) {
         Notifications.error(__('There was an error removing this service.'));
       }
+    }
+
+    /*
+      FIXME
+      this is a hack because it's impossible to access the current scope inside of
+      pf-data-list, and pf-data-list's actionButtons doesn't support hiding buttons
+      based on a condition
+      so the button gets .open-console-button instead of ng-click="vm.openConsole(item)"
+      and we're abusing onClick to verify the event came from that button and call
+      openConsole if so
+     */
+    function maybeOpenConsole(item, event) {
+      var $target = jQuery(event.target);
+      if ($target.is('.open-console-button') || $target.is('.open-console-button *')) {
+        openConsole(item);
+      }
+    }
+
+    function openConsole(vm) {
+      console.log('openConsole', vm);
     }
 
     function editServiceModal() {

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -175,17 +175,34 @@
 
       function consoleOpen(results) {
         // FIXME: may want to support results.remote_url as well (but haven't seen one in the wild yet)
+        switch (results.proto) {
+          case 'spice':
+            openSpice(results);
+            break;
+          case 'vnc':
+            openVnc(results);
+            break;
+          default:
+            logger.error(__("Unsupported console protocol returned:"), results.proto);
+        }
+      }
 
-        console.log('consoleOpen', results);
-        /* novnc:
+      function openSpice(results) {
+        // TODO
+        console.log('TODO spice', results);
+      }
 
-           /bower_components/no-vnc/vnc_auto.html
-             ?host=localhost
-             &port=3000
-             &true_color=1
-             &path=ws/console/ea713e07ffe1ea9a029bf97202cb9798
-             (&encrypt=1 if SSL)
-         */
+      function openVnc(results) {
+        var url = '/bower_components/no-vnc/vnc_auto.html' +
+          '?host=localhost' + // TODO not always
+          '&port=3000' +  // TODO huh.. either 3000 or need to change server/app.js to proxy ws as well
+          '&true_color=1' +
+          '&path=' + results.url +
+          '&password=' + results.secret;
+
+        // TODO if SSL: url += '&encrypt=1'
+
+        window.open(url);
       }
     }
 

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -158,10 +158,10 @@
           .then(function(response) {
             var task = response.data;
 
-            if ((task.state == 'Finished') && (task.status == 'Ok')) {
+            if ((task.state === 'Finished') && (task.status === 'Ok')) {
               // success
               consoleOpen(task.task_results);
-            } else if ((task.state == 'Queued') && (task.status == 'Ok')) {
+            } else if ((task.state === 'Queued') && (task.status === 'Ok')) {
               // waiting
               consoleWatch(url);
             } else {
@@ -174,13 +174,15 @@
       }
 
       function consoleOpen(results) {
-        // FIXME: may want to support results.remote_url as well (but haven't seen one in the wild yet)
         switch (results.proto) {
           case 'spice':
             openSpice(results);
             break;
           case 'vnc':
             openVnc(results);
+            break;
+          case 'remote':
+            openRemote(results);
             break;
           default:
             logger.error(__("Unsupported console protocol returned:"), results.proto);
@@ -192,7 +194,7 @@
           '?host=localhost' + // TODO not always
           '&port=3000' +  // TODO huh.. either 3000 or need to change server/app.js to proxy ws as well
           '&path=' + results.url +
-          '&password=' + results.secret;  // or token?
+          '&password=' + results.secret;
 
         window.open(url);
       }
@@ -208,6 +210,11 @@
         // TODO if SSL: url += '&encrypt=1'
 
         window.open(url);
+      }
+
+      function openRemote(results) {
+        // openstack
+        window.open(results.remote_url);
       }
     }
 

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -52,7 +52,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, Notifications, jQuery, $http, $timeout, logger) {
+  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, Notifications, jQuery, $http, $timeout, logger, $location) {
     var vm = this;
 
     vm.showRemoveService = $state.actionFeatures.service_delete.show;
@@ -191,23 +191,27 @@
 
       function openSpice(results) {
         var url = '/bower_components/spice-html5-bower/spiceHTML5/spice_auto.html' +
-          '?host=localhost' + // TODO not always
-          '&port=3000' +  // TODO huh.. either 3000 or need to change server/app.js to proxy ws as well
+          '?host=' + $location.host() +
+          '&port=' + $location.port() +
           '&path=' + results.url +
           '&password=' + results.secret;
+
+        // encrypt is divined automagically in spice_auto
 
         window.open(url);
       }
 
       function openVnc(results) {
         var url = '/bower_components/no-vnc/vnc_auto.html' +
-          '?host=localhost' + // TODO not always
-          '&port=3000' +  // TODO huh.. either 3000 or need to change server/app.js to proxy ws as well
-          '&true_color=1' +
+          '?host=' + $location.host() +
+          '&port=' + $location.port() +
           '&path=' + results.url +
-          '&password=' + results.secret;
+          '&password=' + results.secret +
+          '&true_color=1';
 
-        // TODO if SSL: url += '&encrypt=1'
+        if ($location.protocol() === 'https') {
+          url += '&encrypt=1'
+        }
 
         window.open(url);
       }

--- a/client/index.html
+++ b/client/index.html
@@ -125,6 +125,7 @@
   <script src="/client/app/resources/authentication-api.factory.js"></script>
   <script src="/client/app/resources/collections-api.factory.js"></script>
   <script src="/client/app/services/blueprints-state.service.js"></script>
+  <script src="/client/app/services/consoles.service.js"></script>
   <script src="/client/app/services/dialog-field-refresh.service.js"></script>
   <script src="/client/app/services/marketplace-state.service.js"></script>
   <script src="/client/app/services/messages.service.js"></script>


### PR DESCRIPTION
This adds support for showing a VNC or SPICE consoles under My Services... (And openstack remote_url consoles.)

Depends on https://github.com/ManageIQ/manageiq/pull/8306 (and https://github.com/ManageIQ/manageiq/pull/8378 for openstack).

Screenshot (one machine is off, one is on but doesn't support consoles, and the other is on and does, so has an extra button):

![console1](https://cloud.githubusercontent.com/assets/289743/14882230/0fd4eefc-0d27-11e6-9efe-7f90c724e45f.png)

Spice console: 
![console_spice](https://cloud.githubusercontent.com/assets/289743/14953210/e1c09380-1056-11e6-8a47-56364a28f5fd.png)

VNC console:
![console_vnc](https://cloud.githubusercontent.com/assets/289743/14953215/e761b6b6-1056-11e6-9f23-902ab85ac0a7.png)

Openstack console:
![console_openstack](https://cloud.githubusercontent.com/assets/289743/14954427/e252e1bc-1061-11e6-8901-1845b6e19e3a.png)


TODO

   * ~~devel-mode ws proxy in server/app.js~~ - will do in a separate PR - https://github.com/ManageIQ/manageiq-ui-self_service/pull/44
   * [x] move to service

Note that without a proxy in the node app, these changes can only work on the appliance.