### PR TITLE
Reload - go to original state, not dashboard

### DIFF
--- a/client/app/config/authorization.config.js
+++ b/client/app/config/authorization.config.js
@@ -88,17 +88,19 @@
       });
 
       Session.loadUser()
-        .then(rbacDashboardOrLogin)
+        .then(rbacReloadOrLogin(toState, toParams))
         .catch(badUser);
     }
 
-    function rbacDashboardOrLogin() {
-      if (Session.activeNavigationFeatures()) {
-        $state.go('dashboard');
-      } else {
-        Session.privileges_error = true;
-        $state.go('login');
-      }
+    function rbacReloadOrLogin(toState, toParams) {
+      return function() {
+        if (Session.activeNavigationFeatures()) {
+          $state.go(toState, toParams);
+        } else {
+          Session.privileges_error = true;
+          $state.go('login');
+        }
+      };
     }
 
     function badUser(error) {


### PR DESCRIPTION
Previously, `rbacDashboardOrLogin` - would redirect to dashboard when everything is fine - that breaks expectations of what reloading means, *and* is terrrible for development. So this PR makes reload work as expected.

@romanblanco you mind find this useful ;)

@AparnaKarve mind reviewing? I *think* it shouldn't really break RBAC that much, but if we really want to check everything, I *can* make RBAC checks happen on any state change (and associate the required features with each state)..