### PR TITLE
Service details - fix typo leading to bad power on/suspend icon

### DIFF
--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -189,8 +189,8 @@
             <div class="col-lg-2 col-md-3 hidden-sm hidden-xs">
               <span class="no-wrap">
                 <i class="fa pficon fa-power-off" ng-if="item.power_state == 'off'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
-                <i class="pficon pficon-ok" ng-if="item.request_state == 'on'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
-                <i class="fa pficon fa-pause" ng-if="item.request_state == 'suspended'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
+                <i class="pficon pficon-ok" ng-if="item.power_state == 'on'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
+                <i class="fa pficon fa-pause" ng-if="item.power_state == 'suspended'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
                 {{ item.power_state }}
               </span>
             </div>


### PR DESCRIPTION
Really just `s/request_state/power_state/`

![i36](https://cloud.githubusercontent.com/assets/289743/14883072/a8d1f0c4-0d2b-11e6-93d6-ec041eeee9cf.png)

Closes #36 