### PR TITLE
Devel mode: proxy websockets for consoles to the right place

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -356,7 +356,10 @@ module.exports = (function() {
       temp + '**/*.css'
     ],
     browserSyncOptions: {
-      proxy: 'localhost:' + (process.env.PORT || '8001'),
+      proxy: {
+        target: 'localhost:' + (process.env.PORT || '8001'),
+        ws: true,
+      },
       port: 3001,
       startPath: '/self_service/',
       files: [],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "bower": "^1.3.0",
-    "browser-sync": "^2.2.4",
+    "browser-sync": "^2.8.1",
     "chai": "^2.1.1",
     "chai-as-promised": "^4.3.0",
     "chalk": "^1.0.0",

--- a/server/app.js
+++ b/server/app.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+var http = require('http');
 var express = require('express');
 var bodyParser = require('body-parser');
 var favicon = require('serve-favicon');
@@ -11,6 +12,7 @@ var four0four = require('./utils/404')();
 var proxyService = require('./utils/proxy')();
 var serviceApp = require('./utils/serviceApp');
 var serviceApi = require('./utils/serviceApi');
+var wsProxy = require('./utils/wsProxy');
 
 var app = express();
 
@@ -73,7 +75,14 @@ switch (environment) {
     break;
 }
 
-app.listen(port, function() {
+var server = http.createServer(app);
+
+server.on('upgrade', function (req, socket, head) {
+  console.log('PROXY(ws,upgrade): ' + req.url);
+  wsProxy.ws(req, socket, head);
+});
+
+server.listen(port, function() {
   console.log('Express server listening on port ' + port);
   console.log('env = ' + app.get('env') + '\n__dirname = '
     + __dirname + '\nprocess.cwd = ' + process.cwd());

--- a/server/utils/wsProxy.js
+++ b/server/utils/wsProxy.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-undef */
+
+'use strict';
+
+var httpProxy = require('http-proxy');
+var proxyService = require('./proxy')();
+
+var proxyHost = proxyService.proxyHost();
+var proxyTarget = 'http://' + proxyHost;
+
+var wsProxy = httpProxy.createProxyServer({
+  target: proxyTarget,
+  ws: true,
+});
+
+module.exports = wsProxy;


### PR DESCRIPTION
This is to enable consoles (#39) even in devel mode...

The problem is that we get info to open, say, `/ws/console/12345`, which is all we need on the appliance, since both the websocket and the SSUI are served from the same host & port ... but in devel mode, `127.0.0.1:3001` != `localhost:3000` - so we need a proxy, the same way we're doing for the API.

Also needed to support server notifications..

Closes ManageIQ/manageiq#8215