### PR TITLE
Fix language code returned by ManageIQ rest API

### DIFF
--- a/client/app/config/gettext.config.js
+++ b/client/app/config/gettext.config.js
@@ -10,9 +10,9 @@
     gettextCatalog.debug = false;
 
     gettextCatalog.loadAndSet = function(lang) {
-      gettextCatalog.setCurrentLanguage(lang);
-
       if (lang) {
+        lang = lang.replace('_', '-');
+        gettextCatalog.setCurrentLanguage(lang);
         gettextCatalog.loadRemote("gettext/json/" + lang + "/manageiq-ui-self_service.json");
       }
     };


### PR DESCRIPTION
When setting user language is self-service, we rely on user's language preference as returned
by the rest api. In the case of language variants (such as zh_CN), the rest api returns the language
name with underscores (i.e. as 'zh_CN'), while the catalogs as returned from translators
contain a dash (i.e. 'zh-CN').

This mismatch would cause the self-service application not to be able to find the chinese translation
catalog.

@himdel 