### PR TITLE
Shopping cart - order history

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -25,7 +25,7 @@
   "strict"        : false,    // true: Requires all functions run in ES5 Strict Mode
   "maxparams"     : 10,       // {int} Max number of formal params allowed per function
   "maxdepth"      : 4,        // {int} Max depth of nested blocks (within functions)
-  "maxstatements" : 32,       // {int} Max number statements per function
+  "maxstatements" : 64,       // {int} Max number statements per function
   "maxcomplexity" : 12,       // {int} Max cyclomatic complexity per function
   "maxlen"        : 160,      // {int} Max number of characters per line
 

--- a/client/app/blocks/directive-options/directive-options.factory.js
+++ b/client/app/blocks/directive-options/directive-options.factory.js
@@ -47,7 +47,7 @@
     }
 
     function booleanConverter(value) {
-      return 'true' === value.toLowerCase();
+      return value.toLowerCase() === 'true';
     }
 
     function regExpConverter(value) {

--- a/client/app/components/request-list/request-list.directive.js
+++ b/client/app/components/request-list/request-list.directive.js
@@ -1,0 +1,28 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .directive('requestList', RequestListDirective);
+
+  /** @ngInject */
+  function RequestListDirective() {
+    var directive = {
+      restrict: 'E',
+      scope: {
+        'items': '<',
+        'config': '<?',
+      },
+      templateUrl: 'app/components/request-list/request-list.html',
+      controller: RequestListController,
+      controllerAs: 'vm',
+      bindToController: true
+    };
+
+    return directive;
+
+    /** @ngInject */
+    function RequestListController() {
+      var vm = this;
+    }
+  }
+})();

--- a/client/app/components/request-list/request-list.html
+++ b/client/app/components/request-list/request-list.html
@@ -4,8 +4,8 @@
       <span class="no-wrap">
         <span class="ss-list-view__title-img">
           <span class="ss-list-view__title-img__center"></span>
-          <img class="ss-list-view__title-img__logo" ng-src="{{ ::item.picture.image_href }}" ng-if=" ::item.picture.image_href"/>
-          <img class="ss-list-view__title-img__logo" src="images/service.png" ng-if=" ::!item.picture.image_href"/>
+          <img class="ss-list-view__title-img__logo" ng-src="{{ item.picture.image_href }}" ng-if="item.picture.image_href" />
+          <img class="ss-list-view__title-img__logo" src="images/service.png" ng-if="!item.picture.image_href" />
         </span>
         {{ item.description }}
       </span>

--- a/client/app/components/request-list/request-list.html
+++ b/client/app/components/request-list/request-list.html
@@ -1,0 +1,32 @@
+<div pf-list-view id="requestList" config="vm.config" items="vm.items">
+  <div class="row">
+    <div class="col-lg-5 col-md-5 col-sm-8 col-xs-8">
+      <span class="no-wrap">
+        <span class="ss-list-view__title-img">
+          <span class="ss-list-view__title-img__center"></span>
+          <img class="ss-list-view__title-img__logo" ng-src="{{ ::item.picture.image_href }}" ng-if=" ::item.picture.image_href"/>
+          <img class="ss-list-view__title-img__logo" src="images/service.png" ng-if=" ::!item.picture.image_href"/>
+        </span>
+        {{ item.description }}
+      </span>
+    </div>
+    <div class="col-lg-2 col-md-3 col-sm-4 col-xs-4">
+      <span class="no-wrap">
+        <strong translate>ID </strong>&nbsp;{{ item.id }}
+      </span>
+    </div>
+    <div class="col-lg-3 hidden-md hidden-sm hidden-xs">
+      <span class="no-wrap">
+        <strong translate>Requested </strong>&nbsp;{{ item.created_on | date }}
+      </span>
+    </div>
+    <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">
+      <span class="text-capitalize no-wrap">
+        <span class="fa fa-clock-o" ng-if="item.approval_state == 'pending_approval'" tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
+        <span class="pficon-error-circle-o" ng-if="item.approval_state == 'denied'" tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
+        <span class="pficon-ok" ng-if="item.approval_state == 'approved'" tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
+        {{ item.approval_state }}
+      </span>
+    </div>
+  </div>
+</div>

--- a/client/app/resources/collections-api.factory.js
+++ b/client/app/resources/collections-api.factory.js
@@ -58,6 +58,9 @@
       options = options || {};
 
       if (options.expand) {
+        if (angular.isArray(options.expand)) {
+          options.expand = options.expand.join(',');
+        }
         params.push('expand=' + options.expand);
       }
 

--- a/client/app/services/orders-state.service.js
+++ b/client/app/services/orders-state.service.js
@@ -1,0 +1,37 @@
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('OrdersState', OrdersStateFactory);
+
+  /** @ngInject */
+  function OrdersStateFactory() {
+    var service = {};
+
+    service.sort = {
+      isAscending: false,
+      currentField: { id: 'placed_at', title: __('Ordered Date'), sortType: 'numeric' },
+    };
+
+    service.filters = [];
+
+    service.setSort = function(currentField, isAscending) {
+      service.sort.isAscending = isAscending;
+      service.sort.currentField = currentField;
+    };
+
+    service.getSort = function() {
+      return service.sort;
+    };
+
+    service.setFilters = function(filterArray) {
+      service.filters = filterArray;
+    };
+
+    service.getFilters = function() {
+      return service.filters;
+    };
+
+    return service;
+  }
+})();

--- a/client/app/services/requests-state.service.js
+++ b/client/app/services/requests-state.service.js
@@ -6,13 +6,13 @@
 
   /** @ngInject */
   function RequestsStateFactory() {
-    var service = {};   
+    var service = {};
 
     service.sort = {
       isAscending: false,
       currentField: { id: 'requested', title: __('Request Date'), sortType: 'numeric' }
     };
-    
+
     service.filters = [];
 
     service.setSort = function(currentField, isAscending) {

--- a/client/app/states/blueprints/list/list.state.js
+++ b/client/app/states/blueprints/list/list.state.js
@@ -251,11 +251,11 @@
     }
 
     function matchesFilter(item, filter) {
-      if ('name' === filter.id) {
+      if (filter.id === 'name') {
         return item.name.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
-      } else if ('visibility' === filter.id) {
+      } else if (filter.id === 'visibility') {
         return item.visibility.name.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
-      } else if ('catalog' === filter.id) {
+      } else if (filter.id === 'catalog') {
         return item.catalog.name.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
       }
 

--- a/client/app/states/blueprints/list/list.state.js
+++ b/client/app/states/blueprints/list/list.state.js
@@ -210,13 +210,6 @@
     }
 
     function filterChange(filters) {
-      vm.filtersText = '';
-      angular.forEach(filters, filterTextFactory);
-
-      function filterTextFactory(filter) {
-        vm.filtersText += filter.title + ' : ' + filter.value + '\n';
-      }
-
       applyFilters(filters);
       vm.toolbarConfig.filterConfig.resultsCount = vm.blueprintsList.length;
     }

--- a/client/app/states/marketplace/list/list.state.js
+++ b/client/app/states/marketplace/list/list.state.js
@@ -123,13 +123,6 @@
     }
 
     function filterChange(filters) {
-      vm.filtersText = '';
-      angular.forEach(filters, filterTextFactory);
-
-      function filterTextFactory(filter) {
-        vm.filtersText += filter.title + ' : ' + filter.value + '\n';
-      }
-
       applyFilters(filters);
       vm.toolbarConfig.filterConfig.resultsCount = vm.serviceTemplatesList.length;
     }

--- a/client/app/states/requests/list/list.html
+++ b/client/app/states/requests/list/list.html
@@ -1,45 +1,49 @@
-<div class="row">
-  <div class="col-md-12 ">
-    <div pf-toolbar id="requestToolbar" config="vm.toolbarConfig"></div>
-  </div>
-</div>
-
-<pf-notification-list></pf-notification-list>
-
-<div class="col-md-12 list-view-container">
-  <request-list items="vm.requestsList" config="vm.listConfig"></request-list>
-</div>
-
-<br />
-<h2 translate>My Orders</h2>
-
-<div class="col-md-12 list-view-container">
-  <div pf-data-list id="orderList" config="vm.orderListConfig" items="vm.orders">
+<tabset>
+  <tab heading="My Requests">
     <div class="row">
-      <div class="col-lg-5 col-md-5 col-sm-8 col-xs-8">
-        <span class="no-wrap">
-          <span class="ss-list-view__title-img">
-            <span class="ss-list-view__title-img__center"></span>
-            <img class="ss-list-view__title-img__logo" src="images/miq_logo_transparent.png" />
-          </span>
-          {{ item.name }}
-        </span>
-      </div>
-      <div class="col-lg-2 col-md-3 col-sm-4 col-xs-4">
-        <span class="no-wrap">
-          <strong translate>ID </strong>&nbsp;{{ item.id }}
-        </span>
-      </div>
-      <div class="col-lg-3 hidden-md hidden-sm hidden-xs">
-        <span class="no-wrap">
-          <strong translate>ordered </strong>&nbsp;{{ item.placed_at | date }}
-        </span>
-      </div>
-      <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">
-        <span class="no-wrap" translate-plural="{{ $count }} items" translate translate-n="item.service_requests.length || 0">
-          {{ $count }} item
-        </span>
+      <div class="col-md-12 ">
+        <div pf-toolbar id="requestToolbar" config="vm.toolbarConfig"></div>
       </div>
     </div>
-  </div>
-</div>
+
+    <pf-notification-list></pf-notification-list>
+
+    <div class="col-md-12 list-view-container">
+      <request-list items="vm.requestsList" config="vm.listConfig"></request-list>
+    </div>
+  </tab>
+  <tab heading="My Orders">
+    <pf-notification-list></pf-notification-list>
+
+    <div class="col-md-12 list-view-container">
+      <div pf-list-view id="orderList" config="vm.orderListConfig" items="vm.orders">
+        <div class="row">
+          <div class="col-lg-5 col-md-5 col-sm-8 col-xs-8">
+            <span class="no-wrap">
+              <span class="ss-list-view__title-img">
+                <span class="ss-list-view__title-img__center"></span>
+                <img class="ss-list-view__title-img__logo" src="images/miq_logo_transparent.png" />
+              </span>
+              {{ item.name }}
+            </span>
+          </div>
+          <div class="col-lg-2 col-md-3 col-sm-4 col-xs-4">
+            <span class="no-wrap">
+              <strong translate>ID </strong>&nbsp;{{ item.id }}
+            </span>
+          </div>
+          <div class="col-lg-3 hidden-md hidden-sm hidden-xs">
+            <span class="no-wrap">
+              <strong translate>ordered </strong>&nbsp;{{ item.placed_at | date }}
+            </span>
+          </div>
+          <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">
+            <span class="no-wrap" translate-plural="{{ $count }} items" translate translate-n="item.service_requests.length || 0">
+              {{ $count }} item
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </tab>
+</tabset>

--- a/client/app/states/requests/list/list.html
+++ b/client/app/states/requests/list/list.html
@@ -8,14 +8,14 @@
 
     <pf-notification-list></pf-notification-list>
 
-    <div class="col-md-12 list-view-container">
+    <div class="col-md-12 list-view-container -in-a-tab">
       <request-list items="vm.requestsList" config="vm.listConfig"></request-list>
     </div>
   </tab>
   <tab heading="My Orders">
     <pf-notification-list></pf-notification-list>
 
-    <div class="col-md-12 list-view-container">
+    <div class="col-md-12 list-view-container -in-a-tab -without-toolbar">
       <div pf-list-view id="orderList" config="vm.orderListConfig" items="vm.orders">
         <div class="row">
           <div class="col-lg-5 col-md-5 col-sm-8 col-xs-8">

--- a/client/app/states/requests/list/list.html
+++ b/client/app/states/requests/list/list.html
@@ -13,10 +13,16 @@
     </div>
   </tab>
   <tab heading="My Orders">
+    <div class="row">
+      <div class="col-md-12 ">
+        <div pf-toolbar config="vm.orderToolbarConfig"></div>
+      </div>
+    </div>
+
     <pf-notification-list></pf-notification-list>
 
     <div class="col-md-12 list-view-container -in-a-tab -without-toolbar">
-      <div pf-list-view id="orderList" config="vm.orderListConfig" items="vm.orders">
+      <div pf-list-view id="orderList" config="vm.orderListConfig" items="vm.ordersList">
         <div class="row">
           <div class="col-lg-5 col-md-5 col-sm-8 col-xs-8">
             <span class="no-wrap">
@@ -34,7 +40,7 @@
           </div>
           <div class="col-lg-3 hidden-md hidden-sm hidden-xs">
             <span class="no-wrap">
-              <strong translate>ordered </strong>&nbsp;{{ ::(item.placed_at || item.updated_at) | date }}</h4>
+              <strong translate>ordered </strong>&nbsp;{{ (item.placed_at || item.updated_at) | date }}</h4>
             </span>
           </div>
           <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">

--- a/client/app/states/requests/list/list.html
+++ b/client/app/states/requests/list/list.html
@@ -7,36 +7,5 @@
 <pf-notification-list></pf-notification-list>
 
 <div class="col-md-12 list-view-container">
-  <div pf-list-view id="requestList" config="vm.listConfig" items="vm.requestsList">
-    <div class="row">
-      <div class="col-lg-5 col-md-5 col-sm-8 col-xs-8">
-        <span class="no-wrap">
-          <span class="ss-list-view__title-img">
-            <span class="ss-list-view__title-img__center"></span>
-            <img class="ss-list-view__title-img__logo" ng-src="{{ ::item.picture.image_href }}" ng-if=" ::item.picture.image_href"/>
-            <img class="ss-list-view__title-img__logo" src="images/service.png" ng-if=" ::!item.picture.image_href"/>
-          </span>
-          {{ item.description }}
-        </span>
-      </div>
-      <div class="col-lg-2 col-md-3 col-sm-4 col-xs-4">
-        <span class="no-wrap">
-          <strong translate>ID </strong>&nbsp;{{ item.id }}
-        </span>
-      </div>
-      <div class="col-lg-3 hidden-md hidden-sm hidden-xs">
-        <span class="no-wrap">
-          <strong translate>Requested </strong>&nbsp;{{ item.created_on | date }}
-        </span>
-      </div>
-      <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">
-        <span class="text-capitalize no-wrap">
-          <span class="fa fa-clock-o" ng-if="item.approval_state == 'pending_approval'" tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
-          <span class="pficon-error-circle-o" ng-if="item.approval_state == 'denied'" tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
-          <span class="pficon-ok" ng-if="item.approval_state == 'approved'" tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
-          {{ item.approval_state }}
-        </span>
-      </div>
-    </div>
-  </div>
+  <request-list items="vm.requestsList" config="vm.listConfig"></request-list>
 </div>

--- a/client/app/states/requests/list/list.html
+++ b/client/app/states/requests/list/list.html
@@ -9,3 +9,37 @@
 <div class="col-md-12 list-view-container">
   <request-list items="vm.requestsList" config="vm.listConfig"></request-list>
 </div>
+
+<br />
+<h2 translate>My Orders</h2>
+
+<div class="col-md-12 list-view-container">
+  <div pf-data-list id="orderList" config="vm.orderListConfig" items="vm.orders">
+    <div class="row">
+      <div class="col-lg-5 col-md-5 col-sm-8 col-xs-8">
+        <span class="no-wrap">
+          <span class="ss-list-view__title-img">
+            <span class="ss-list-view__title-img__center"></span>
+            <img class="ss-list-view__title-img__logo" src="images/miq_logo_transparent.png" />
+          </span>
+          {{ item.name }}
+        </span>
+      </div>
+      <div class="col-lg-2 col-md-3 col-sm-4 col-xs-4">
+        <span class="no-wrap">
+          <strong translate>ID </strong>&nbsp;{{ item.id }}
+        </span>
+      </div>
+      <div class="col-lg-3 hidden-md hidden-sm hidden-xs">
+        <span class="no-wrap">
+          <strong translate>ordered </strong>&nbsp;{{ item.placed_at | date }}
+        </span>
+      </div>
+      <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">
+        <span class="no-wrap" translate-plural="{{ $count }} items" translate translate-n="item.service_requests.length || 0">
+          {{ $count }} item
+        </span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/client/app/states/requests/list/list.html
+++ b/client/app/states/requests/list/list.html
@@ -34,7 +34,7 @@
           </div>
           <div class="col-lg-3 hidden-md hidden-sm hidden-xs">
             <span class="no-wrap">
-              <strong translate>ordered </strong>&nbsp;{{ item.placed_at | date }}
+              <strong translate>ordered </strong>&nbsp;{{ ::(item.placed_at || item.updated_at) | date }}</h4>
             </span>
           </div>
           <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">

--- a/client/app/states/requests/list/list.state.js
+++ b/client/app/states/requests/list/list.state.js
@@ -51,11 +51,7 @@
     vm.requestsList = angular.copy(vm.requests);
 
     vm.orders = orders.resources;
-    vm.orderListConfig = {
-      showSelectBox: false,
-      selectionMatchProp: 'id',
-      onClick: handleOrderClick,
-    };
+    vm.ordersList = angular.copy(vm.orders);
 
     if (angular.isDefined($rootScope.notifications) && $rootScope.notifications.data.length > 0) {
       $rootScope.notifications.data.splice(0, $rootScope.notifications.data.length);
@@ -68,6 +64,12 @@
       onClick: handleRequestClick,
     };
 
+    vm.orderListConfig = {
+      showSelectBox: false,
+      selectionMatchProp: 'id',
+      onClick: handleOrderClick,
+    };
+
     vm.toolbarConfig = {
       filterConfig: {
         fields: [
@@ -75,58 +77,108 @@
             id: 'description',
             title:  __('Description'),
             placeholder: __('Filter by Description'),
-            filterType: 'text'
+            filterType: 'text',
           },
           {
             id: 'request_id',
             title: __('Request ID'),
             placeholder: __('Filter by ID'),
-            filterType: 'text'
+            filterType: 'text',
           },
           {
             id: 'request_date',
             title: __('Request Date'),
             placeholder: __('Filter by Request Date'),
-            filterType: 'text'
+            filterType: 'text',
           },
           {
             id: 'approval_state',
             title: __('Request Status'),
             placeholder: __('Filter by Status'),
             filterType: 'select',
-            filterValues: [__('Pending'), __('Denied'), __('Approved')]
-          }
+            filterValues: [__('Pending'), __('Denied'), __('Approved')],
+          },
         ],
         resultsCount: vm.requestsList.length,
         appliedFilters: RequestsState.filterApplied ? RequestsState.getFilters() : [],
-        onFilterChange: filterChange
+        onFilterChange: filterChange,
       },
       sortConfig: {
         fields: [
           {
             id: 'description',
             title: __('Description'),
-            sortType: 'alpha'
+            sortType: 'alpha',
           },
           {
             id: 'id',
             title: __('Request ID'),
-            sortType: 'numeric'
+            sortType: 'numeric',
           },
           {
             id: 'requested',
             title: __('Request Date'),
-            sortType: 'numeric'
+            sortType: 'numeric',
           },
           {
             id: 'status',
             title: __('Request Status'),
-            sortType: 'alpha'
-          }
+            sortType: 'alpha',
+          },
         ],
         onSortChange: sortChange,
         isAscending: RequestsState.getSort().isAscending,
-        currentField: RequestsState.getSort().currentField
+        currentField: RequestsState.getSort().currentField,
+      },
+    };
+
+    vm.orderToolbarConfig = {
+      filterConfig: {
+        fields: [
+           {
+            id: 'name',
+            title:  __('Name'),
+            placeholder: __('Filter by Name'),
+            filterType: 'text',
+          },
+          {
+            id: 'id',
+            title: __('Order ID'),
+            placeholder: __('Filter by ID'),
+            filterType: 'text',
+          },
+          {
+            id: 'placed_at',
+            title: __('Ordered Date'),
+            placeholder: __('Filter by Ordered Date'),
+            filterType: 'text',
+          },
+        ],
+        resultsCount: vm.ordersList.length,
+        appliedFilters: OrdersState.filterApplied ? OrdersState.getFilters() : [],
+        onFilterChange: orderFilterChange,
+      },
+      sortConfig: {
+        fields: [
+          {
+            id: 'name',
+            title: __('Name'),
+            sortType: 'alpha',
+          },
+          {
+            id: 'id',
+            title: __('Order ID'),
+            sortType: 'numeric',
+          },
+          {
+            id: 'placed_at',
+            title: __('Ordered Date'),
+            sortType: 'numeric',
+          },
+        ],
+        onSortChange: orderSortChange,
+        isAscending: OrdersState.getSort().isAscending,
+        currentField: OrdersState.getSort().currentField
       }
     };
 
@@ -136,6 +188,13 @@
       RequestsState.filterApplied = false;
     } else {
       applyFilters();
+    }
+
+    if (OrdersState.filterApplied) {
+      orderFilterChange(OrdersState.getFilters());
+      OrdersState.filterApplied = false;
+    } else {
+      orderApplyFilters();
     }
 
     function handleRequestClick(item, _e) {
@@ -151,6 +210,13 @@
 
       /* Keep track of the current sorting state */
       RequestsState.setSort(sortId, vm.toolbarConfig.sortConfig.isAscending);
+    }
+
+    function orderSortChange(sortId, direction) {
+      vm.ordersList.sort(orderCompareFn);
+
+      /* Keep track of the current sorting state */
+      OrdersState.setSort(sortId, vm.orderToolbarConfig.sortConfig.isAscending);
     }
 
     function compareFn(item1, item2) {
@@ -172,9 +238,31 @@
       return compValue;
     }
 
+    function orderCompareFn(item1, item2) {
+      var compValue = 0;
+      if (vm.orderToolbarConfig.sortConfig.currentField.id === 'name') {
+        compValue = item1.name.localeCompare(item2.name);
+      } else if (vm.orderToolbarConfig.sortConfig.currentField.id === 'id') {
+        compValue = item1.id - item2.id;
+      } else if (vm.orderToolbarConfig.sortConfig.currentField.id === 'placed_at') {
+        compValue = new Date(item1.placed_at || item1.updated_at) - new Date(item2.placed_at || item2.updated_at);
+      }
+
+      if (!vm.orderToolbarConfig.sortConfig.isAscending) {
+        compValue = compValue * -1;
+      }
+
+      return compValue;
+    }
+
     function filterChange(filters) {
       applyFilters(filters);
       vm.toolbarConfig.filterConfig.resultsCount = vm.requestsList.length;
+    }
+
+    function orderFilterChange(filters) {
+      orderApplyFilters(filters);
+      vm.orderToolbarConfig.filterConfig.resultsCount = vm.ordersList.length;
     }
 
     function applyFilters(filters) {
@@ -192,13 +280,34 @@
       sortChange(RequestsState.getSort().currentField, RequestsState.getSort().isAscending);
 
       function filterChecker(item) {
-        if (matchesFilters(item, filters)) {
+        if (matchesFilters(item, filters, requestMatchesFilter)) {
           vm.requestsList.push(item);
         }
       }
     }
 
-    function matchesFilters(item, filters) {
+    function orderApplyFilters(filters) {
+      vm.ordersList = [];
+      if (filters && filters.length > 0) {
+        angular.forEach(vm.orders, filterChecker);
+      } else {
+        vm.ordersList = vm.orders;
+      }
+
+      /* Keep track of the current filtering state */
+      OrdersState.setFilters(filters);
+
+      /* Make sure sorting direction is maintained */
+      orderSortChange(OrdersState.getSort().currentField, OrdersState.getSort().isAscending);
+
+      function filterChecker(item) {
+        if (matchesFilters(item, filters, orderMatchesFilter)) {
+          vm.ordersList.push(item);
+        }
+      }
+    }
+
+    function matchesFilters(item, filters, matchesFilter) {
       var matches = true;
       angular.forEach(filters, filterMatcher);
 
@@ -213,7 +322,7 @@
       return matches;
     }
 
-    function matchesFilter(item, filter) {
+    function requestMatchesFilter(item, filter) {
       if (filter.id === 'description') {
         return item.description.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
       } else if (filter.id === 'approval_state') {
@@ -231,6 +340,18 @@
         return String(item.id).toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
       } else if (filter.id === 'request_date') {
         return $filter('date')(item.created_on).toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
+      }
+
+      return false;
+    }
+
+    function orderMatchesFilter(item, filter) {
+      if (filter.id === 'name') {
+        return item.name.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
+      } else if (filter.id === 'id') {
+        return String(item.id).toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
+      } else if (filter.id === 'placed_at') {
+        return $filter('date')(item.placed_at || item.updated_at).toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
       }
 
       return false;

--- a/client/app/states/requests/list/list.state.js
+++ b/client/app/states/requests/list/list.state.js
@@ -173,13 +173,6 @@
     }
 
     function filterChange(filters) {
-      vm.filtersText = '';
-      angular.forEach(filters, filterTextFactory);
-
-      function filterTextFactory(filter) {
-        vm.filtersText += filter.title + ' : ' + filter.value + '\n';
-      }
-
       applyFilters(filters);
       vm.toolbarConfig.filterConfig.resultsCount = vm.requestsList.length;
     }

--- a/client/app/states/requests/list/list.state.js
+++ b/client/app/states/requests/list/list.state.js
@@ -214,7 +214,7 @@
     }
 
     function matchesFilter(item, filter) {
-      if ('description' === filter.id) {
+      if (filter.id === 'description') {
         return item.description.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
       } else if (filter.id === 'approval_state') {
         var value;
@@ -229,7 +229,7 @@
         return item.approval_state === value;
       } else if (filter.id === 'request_id') {
         return String(item.id).toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
-      } else if ('request_date' === filter.id) {
+      } else if (filter.id === 'request_date') {
         return $filter('date')(item.created_on).toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
       }
 

--- a/client/app/states/requests/list/list.state.js
+++ b/client/app/states/requests/list/list.state.js
@@ -51,6 +51,11 @@
     vm.requestsList = angular.copy(vm.requests);
 
     vm.orders = orders.resources;
+    vm.orderListConfig = {
+      showSelectBox: false,
+      selectionMatchProp: 'id',
+      onClick: handleOrderClick,
+    };
 
     if (angular.isDefined($rootScope.notifications) && $rootScope.notifications.data.length > 0) {
       $rootScope.notifications.data.splice(0, $rootScope.notifications.data.length);
@@ -59,8 +64,8 @@
     vm.listConfig = {
       selectItems: false,
       showSelectBox: false,
-      selectionMatchProp: 'request_status',
-      onClick: handleClick
+      selectionMatchProp: 'id',
+      onClick: handleRequestClick,
     };
 
     vm.toolbarConfig = {
@@ -133,8 +138,12 @@
       applyFilters();
     }
 
-    function handleClick(item, e) {
-      $state.go('requests.details', {requestId: item.id});
+    function handleRequestClick(item, _e) {
+      $state.go('requests.details', { requestId: item.id });
+    }
+
+    function handleOrderClick(item, _e) {
+      $state.go('requests.order_details', { serviceOrderId: item.id });
     }
 
     function sortChange(sortId, direction) {

--- a/client/app/states/requests/list/list.state.js
+++ b/client/app/states/requests/list/list.state.js
@@ -43,7 +43,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, requests, orders, RequestsState, $filter, $rootScope, lodash) {
+  function StateController($state, requests, orders, RequestsState, OrdersState, $filter, $rootScope, lodash) {
     var vm = this;
 
     vm.title = __('Request List');

--- a/client/app/states/requests/list/list.state.js
+++ b/client/app/states/requests/list/list.state.js
@@ -18,7 +18,8 @@
         controllerAs: 'vm',
         title: N_('Request List'),
         resolve: {
-          requests: resolveRequests
+          requests: resolveRequests,
+          orders: resolveOrders,
         }
       }
     };
@@ -34,12 +35,22 @@
   }
 
   /** @ngInject */
-  function StateController($state, requests, RequestsState, $filter, $rootScope, lodash) {
+  function resolveOrders(CollectionsApi) {
+    return CollectionsApi.query('service_orders', {
+      expand: ['resources', 'service_requests'],
+      filter: ['state=ordered'],
+    });
+  }
+
+  /** @ngInject */
+  function StateController($state, requests, orders, RequestsState, $filter, $rootScope, lodash) {
     var vm = this;
 
     vm.title = __('Request List');
     vm.requests = requests.resources;
     vm.requestsList = angular.copy(vm.requests);
+
+    vm.orders = orders.resources;
 
     if (angular.isDefined($rootScope.notifications) && $rootScope.notifications.data.length > 0) {
       $rootScope.notifications.data.splice(0, $rootScope.notifications.data.length);

--- a/client/app/states/requests/list/list.state.spec.js
+++ b/client/app/states/requests/list/list.state.spec.js
@@ -33,7 +33,7 @@ describe('Dashboard', function() {
     beforeEach(function() {
       bard.inject('$controller', '$log', '$state', '$rootScope', 'Notifications');
 
-      controller = $controller($state.get('requests.list').controller, {requests: requests});
+      controller = $controller($state.get('requests.list').controller, {requests: requests, orders: []});
       $rootScope.$apply();
     });
 

--- a/client/app/states/requests/list/list.state.spec.js
+++ b/client/app/states/requests/list/list.state.spec.js
@@ -23,8 +23,16 @@ describe('Dashboard', function() {
 
   describe('controller', function() {
     var controller;
+
     var requests = {
       name: 'requests',
+      count: 1,
+      subcount: 1,
+      resources: []
+    };
+
+    var orders = {
+      name: 'orders',
       count: 1,
       subcount: 1,
       resources: []
@@ -33,7 +41,7 @@ describe('Dashboard', function() {
     beforeEach(function() {
       bard.inject('$controller', '$log', '$state', '$rootScope', 'Notifications');
 
-      controller = $controller($state.get('requests.list').controller, {requests: requests, orders: []});
+      controller = $controller($state.get('requests.list').controller, {requests: requests, orders: orders});
       $rootScope.$apply();
     });
 

--- a/client/app/states/requests/order_details/order_details.html
+++ b/client/app/states/requests/order_details/order_details.html
@@ -19,7 +19,7 @@
               </div>
               <div class="ss-details-header__title">
                 <h2>{{ ::vm.order.name }}</h2>
-                <h4>ordered {{ ::vm.order.placed_at | date }}</h4>
+                <h4>ordered {{ ::(vm.order.placed_at || vm.order.updated_at) | date }}</h4>
               </div>
             </div>
           </div>

--- a/client/app/states/requests/order_details/order_details.html
+++ b/client/app/states/requests/order_details/order_details.html
@@ -1,0 +1,35 @@
+<ol class="breadcrumb">
+  <li>
+    <a ui-sref="^"> <span class="fa fa-angle-double-left"/>&nbsp;{{'Back to My Requests'|translate}}</a>
+  </li>
+  <li class="active"> <strong translate>Orders:</strong> {{ ::vm.order.name }}
+  </li>
+</ol>
+
+<div class="ss-details-wrapper">
+  <div class="panel panel-default ss-details-panel">
+    <div class="panel-body">
+      <section>
+        <div class="col-md-12 ss-details-header">
+          <div class="row">
+            <div class="col-md-12">
+              <div class="ss-details-header__title-img">
+                <span class="ss-details-header__title-img__center"></span>
+                <img class="ss-details-header__title-img__logo" src="images/miq_logo_transparent.png" />
+              </div>
+              <div class="ss-details-header__title">
+                <h2>{{ ::vm.order.name }}</h2>
+                <h4>ordered {{ ::vm.order.placed_at | date }}</h4>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+  <div class="panel panel-default ss-details-panel">
+    <div class="panel-body">
+      <request-list items="vm.order.service_requests" config="vm.requestListConfig"></request-list>
+    </div>
+  </div>
+</div>

--- a/client/app/states/requests/order_details/order_details.state.js
+++ b/client/app/states/requests/order_details/order_details.state.js
@@ -1,0 +1,50 @@
+(function() {
+  'use strict';
+
+  angular.module('app.states')
+    .run(appRun);
+
+  /** @ngInject */
+  function appRun(routerHelper) {
+    routerHelper.configureStates(getStates());
+  }
+
+  function getStates() {
+    return {
+      'requests.order_details': {
+        url: '/order/:serviceOrderId',
+        templateUrl: 'app/states/requests/order_details/order_details.html',
+        controller: StateController,
+        controllerAs: 'vm',
+        title: N_('Order Details'),
+        resolve: {
+          order: resolveOrder,
+        }
+      }
+    };
+  }
+
+  /** @ngInject */
+  function resolveOrder($stateParams, CollectionsApi) {
+    return CollectionsApi.get('service_orders', $stateParams.serviceOrderId, {
+      expand: ['resources', 'service_requests'],
+    });
+  }
+
+  /** @ngInject */
+  function StateController(order, $state) {
+    var vm = this;
+
+    vm.order = order;
+
+    vm.requestListConfig = {
+      showSelectBox: false,
+      selectionMatchProp: 'id',
+      onClick: handleRequestClick,
+    };
+
+    function handleRequestClick(item, _e) {
+      $state.go('requests.details', { requestId: item.id });
+    }
+  }
+})();

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -238,15 +238,15 @@
     }
 
     function matchesFilter(item, filter) {
-      if ('name' === filter.id) {
+      if (filter.id === 'name') {
         return item.name.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
-      } else if ('vms' === filter.id) {
+      } else if (filter.id === 'vms') {
         return String(item.v_total_vms).toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
-      } else if ('owner' === filter.id && angular.isDefined(item.evm_owner)) {
+      } else if (filter.id === 'owner' && angular.isDefined(item.evm_owner)) {
         return item.evm_owner.name.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
-      } else if ('retirement' === filter.id) {
+      } else if (filter.id === 'retirement') {
         return checkRetirementDate(item, filter.value.toLowerCase());
-      } else if ('created' === filter.id) {
+      } else if (filter.id === 'created') {
         return $filter('date')(item.created_at).toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
       }
 

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -197,13 +197,6 @@
     }
 
     function filterChange(filters) {
-      vm.filtersText = '';
-      angular.forEach(filters, filterTextFactory);
-
-      function filterTextFactory(filter) {
-        vm.filtersText += filter.title + ' : ' + filter.value + '\n';
-      }
-
       applyFilters(filters);
       vm.toolbarConfig.filterConfig.resultsCount = vm.servicesList.length;
     }

--- a/client/assets/sass/_list-view.sass
+++ b/client/assets/sass/_list-view.sass
@@ -8,6 +8,13 @@
   .alert
     margin: 20px 0
 
+  &.-in-a-tab
+    height: calc(100vh - 184px)
+  &.-without-toolbar
+    height: calc(100vh - 61px)
+  &.-in-a-tab.-without-toolbar
+    height: calc(100vh - 96px)
+
 .list-view-pf
   line-height: 45px
   overflow-y: hidden // Adding so tooltips don't cause a second scrollbar in the data list

--- a/client/index.html
+++ b/client/index.html
@@ -147,6 +147,7 @@
   <script src="/client/app/components/navigation/header-nav.directive.js"></script>
   <script src="/client/app/components/navigation/sidebar-nav.directive.js"></script>
   <script src="/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js"></script>
+  <script src="/client/app/components/request-list/request-list.directive.js"></script>
   <script src="/client/app/components/retire-service-modal/retire-service-modal-service.factory.js"></script>
   <script src="/client/app/components/shopping-cart/shopping-cart.directive.js"></script>
   <script src="/client/app/components/ss-card/ss-card.directive.js"></script>
@@ -194,6 +195,7 @@
   <script src="/client/app/states/products/products.state.js"></script>
   <script src="/client/app/states/requests/details/details.state.js"></script>
   <script src="/client/app/states/requests/list/list.state.js"></script>
+  <script src="/client/app/states/requests/order_details/order_details.state.js"></script>
   <script src="/client/app/states/requests/requests.state.js"></script>
   <script src="/client/app/states/services/custom_button_details/custom_button_details.state.js"></script>
   <script src="/client/app/states/services/details/details.state.js"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -170,6 +170,7 @@
   <script src="/client/app/services/messages.service.js"></script>
   <script src="/client/app/services/navcounts.service.js"></script>
   <script src="/client/app/services/navigation.provider.js"></script>
+  <script src="/client/app/services/orders-state.service.js"></script>
   <script src="/client/app/services/polling.service.js"></script>
   <script src="/client/app/services/rbac.service.js"></script>
   <script src="/client/app/services/requests-state.service.js"></script>


### PR DESCRIPTION
This is a follow-up to #33, adding Order history to My requests (under the actual request list right now).

Screenshots:

My Requests with added tabs..
![oh-requests](https://cloud.githubusercontent.com/assets/289743/16410123/881eaeca-3d10-11e6-911f-b22f2339f2cd.png)

My Orders..
![oh-orders](https://cloud.githubusercontent.com/assets/289743/16410134/96204434-3d10-11e6-898e-dfc2c85cb7b2.png)

Order detail..
![oh-order-detail](https://cloud.githubusercontent.com/assets/289743/16410138/9d0c9d42-3d10-11e6-9ee4-fe76aa5a5d4f.png)

(the individual requests have a click-through to a request detail screen)



TODO in a separate `darga/no` PR:
   * rename "My Requests" as "My Orders and Requests"
   * put the "My Orders" tab first
   * remember the last chosen tab (separate url for each?)
   * remove the `updated_at || placed_at` logic