### PR TITLE
Request - fix request_state vs approval_state in detail, use clock not spinner for pending

### DIFF
--- a/client/app/states/requests/details/details.html
+++ b/client/app/states/requests/details/details.html
@@ -42,13 +42,7 @@
                 <div class="form-group">
                   <label class="control-label col-sm-4" translate>Request State</label>
                   <div class="col-sm-8">
-                    <div class="ss-request-state">
-                      <span class="spinner spinner-xs spinner-inline" ng-if="vm.request.request_state == 'pending_approval'"></span>
-                      <span class="pficon-error-circle-o" ng-if="vm.request.request_state == 'denied'"></span>
-                      <span class="pficon-ok" ng-if="vm.request.request_state == 'approved'"></span>
-                      {{ ::item.request_state }}
-                      {{ ::vm.request.request_state }}
-                    </div>
+                    <input class="form-control" disabled value="{{ ::vm.request.request_state }}" />
                   </div>
                 </div>
                 <div class="form-group">
@@ -66,7 +60,12 @@
                 <div class="form-group">
                   <label class="control-label col-sm-4" translate>Request Approval State</label>
                   <div class="col-sm-8">
-                    <input class="form-control" disabled value="{{ ::vm.request.approval_state }}" />
+                    <div class="ss-request-state">
+                      <span class="fa fa-clock-o" ng-if="vm.request.approval_state == 'pending_approval'"></span>
+                      <span class="pficon-error-circle-o" ng-if="vm.request.approval_state == 'denied'"></span>
+                      <span class="pficon-ok" ng-if="vm.request.approval_state == 'approved'"></span>
+                      {{ ::vm.request.approval_state }}
+                    </div>
                   </div>
                 </div>
                 <div class="form-group">

--- a/client/app/states/requests/list/list.html
+++ b/client/app/states/requests/list/list.html
@@ -31,12 +31,9 @@
       </div>
       <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">
         <span class="text-capitalize no-wrap">
-          <span class="spinner spinner-xs spinner-inline" ng-if="item.approval_state == 'pending_approval'"
-          tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
-          <span class="pficon-error-circle-o" ng-if="item.approval_state == 'denied'" 
-          tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
-          <span class="pficon-ok" ng-if="item.approval_state == 'approved'" 
-          tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
+          <span class="fa fa-clock-o" ng-if="item.approval_state == 'pending_approval'" tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
+          <span class="pficon-error-circle-o" ng-if="item.approval_state == 'denied'" tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
+          <span class="pficon-ok" ng-if="item.approval_state == 'approved'" tooltip="{{'The current approval status of the request'|translate}}" tooltip-placement="bottom"></span>
           {{ item.approval_state }}
         </span>
       </div>


### PR DESCRIPTION
In My Requests, an icon is used for each approval_state (approved, pending_approval, denied) - but a spinner was used for pending_approval, which looks misleading because a spinner is usually used to indicate something is loading and does not quite convey the meaning of "waiting for somebody". - updated to use `fa-clock-o` instead.

Also, in the detail, the same icons are used, but were used for request_state, not approval_state, which has completely different states - fixed so that both use approval_state, and request_state has no icon.

@epwinchell thanks for the clock icon idea :)