### PR TITLE
Fix Services and Requests count in dashboard

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "angular-ui-router": "~0.2.15",
     "font-awesome": "~4.4.0",
     "jquery": "~2.1.0",
-    "lodash": "~3.9.0",
+    "lodash": "~4.12.0",
     "moment": "~2.10.0",
     "ngprogress": "~1.1.2",
     "ngstorage": "~0.3.10",

--- a/client/app/states/dashboard/dashboard.html
+++ b/client/app/states/dashboard/dashboard.html
@@ -16,7 +16,7 @@
         <div class="card-pf-body">
           <span class="fa fa-file-text-o"></span>
           <div class="ss-dashboard__card-primary__count">
-            <h2>{{ ::vm.requestsCount.total }}</h2>
+            <h2>{{ vm.requestsCount.total }}</h2>
             <h3 translate>Total Requests</h3>
           </div>
         </div>

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -34,6 +34,11 @@
   }
 
   /** @ngInject */
+  // TODO API in question: /api/requests
+  // TODO with filterValues = ['type=ServiceReconfigureRequest', 'or type=ServiceTemplateProvisionRequest', 'approval_state=pending_approval'];
+  // TODO API OR-ing bug/"design limitation" has forced an implementation change in how we gather count data for Requests
+  // TODO One API call would now be split into two - one for ServiceTemplateProvisionRequest and other for ServiceReconfigureRequest
+
   function resolvePendingRequests(CollectionsApi, $state) {
     if (!$state.navFeatures.requests.show) {
       return undefined;

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -201,11 +201,13 @@
 
     vm.navigateToRequestsList = function(filterValue) {
       RequestsState.setFilters([{'id': 'approval_state', 'title': __('Request Status'), 'value': filterValue}]);
+      RequestsState.filterApplied = true;
       $state.go('requests.list');
     };
 
     vm.navigateToServicesList = function(filterValue) {
       ServicesState.setFilters([{'id': 'retirement', 'title': __('Retirement Date'), 'value': filterValue}]);
+      ServicesState.filterApplied = true;
       $state.go('services.list');
     };
   }

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -80,7 +80,7 @@
 
     var days30 = currentDate.setDate(currentDate.getDate() + 30);
     var date2 = 'retires_on<=' + $filter('date')(days30, 'yyyy-MM-dd');
-    var options = {expand: false, filter: [date1, date2]};
+    var options = {expand: false, filter: ['service_id=nil', date1, date2]};
 
     return CollectionsApi.query('services', options);
   }
@@ -90,7 +90,7 @@
     if (!$state.navFeatures.services.show) {
       return undefined;
     }
-    var options = {expand: false, filter: ['retired=true'] };
+    var options = {expand: false, filter: ['service_id=nil', 'retired=true'] };
 
     return CollectionsApi.query('services', options);
   }
@@ -129,12 +129,12 @@
 
       if (definedServiceIdsServices.subcount > 0) {
         vm.servicesCount.total = definedServiceIdsServices.subcount;
-        vm.servicesCount.current = definedServiceIdsServices.subcount === 0 ? nonRetiredServices.count :
-        retiredServices.subcount + nonRetiredServices.subcount;
 
-        vm.servicesCount.retired = vm.servicesCount.total - vm.servicesCount.current;
+        vm.servicesCount.retired = retiredServices.subcount;
 
         vm.servicesCount.soon = expiringServices.subcount;
+        
+        vm.servicesCount.current = vm.servicesCount.total - vm.servicesCount.retired - vm.servicesCount.soon;
       }
 
       vm.servicesFeature = true;

--- a/client/app/states/dashboard/dashboard.state.spec.js
+++ b/client/app/states/dashboard/dashboard.state.spec.js
@@ -39,9 +39,7 @@ describe('Dashboard', function() {
     var retiredServices = {};
     var resolveNonRetiredServices = {};
     var expiringServices = {};
-    var pendingRequests = {};
-    var approvedRequests = {};
-    var deniedRequests = {};
+    var resolveAllRequests = [];
 
     beforeEach(function() {
       bard.inject('$controller', '$log', '$state', '$rootScope');
@@ -51,9 +49,7 @@ describe('Dashboard', function() {
         retiredServices: retiredServices,
         nonRetiredServices: resolveNonRetiredServices,
         expiringServices: expiringServices,
-        pendingRequests: pendingRequests,
-        approvedRequests: approvedRequests,
-        deniedRequests: deniedRequests
+        allRequests: resolveAllRequests
       };
 
       controller = $controller($state.get('dashboard').controller, controllerResolves);

--- a/client/app/states/requests/list/list.state.js
+++ b/client/app/states/requests/list/list.state.js
@@ -82,7 +82,7 @@
           }
         ],
         resultsCount: vm.requestsList.length,
-        appliedFilters: RequestsState.getFilters(),
+        appliedFilters: RequestsState.filterApplied ? RequestsState.getFilters() : [],
         onFilterChange: filterChange
       },
       sortConfig: {
@@ -114,8 +114,11 @@
       }
     };
 
-    /* Apply the filtering to the data list */
-    filterChange(RequestsState.getFilters());
+    if (RequestsState.filterApplied) {
+      /* Apply the filtering to the data list */
+      filterChange(RequestsState.getFilters());
+      RequestsState.filterApplied = false;
+    }
 
     function handleClick(item, e) {
       $state.go('requests.details', {requestId: item.id});

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -26,7 +26,9 @@
 
   /** @ngInject */
   function resolveServices(CollectionsApi) {
-    var options = {expand: 'resources', attributes: ['picture', 'picture.image_href', 'evm_owner.name', 'v_total_vms']};
+    var options = {expand: 'resources',
+                   attributes: ['picture', 'picture.image_href', 'evm_owner.name', 'v_total_vms'],
+                   filter: ['service_id=nil']};
 
     return CollectionsApi.query('services', options);
   }

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -96,7 +96,7 @@
           }
         ],
         resultsCount: vm.servicesList.length,
-        appliedFilters: ServicesState.getFilters(),
+        appliedFilters: ServicesState.filterApplied ? ServicesState.getFilters() : [],
         onFilterChange: filterChange
       },
       sortConfig: {
@@ -133,8 +133,11 @@
       }
     };
 
-    /* Apply the filtering to the data list */
-    filterChange(ServicesState.getFilters());
+    if (ServicesState.filterApplied) {
+      /* Apply the filtering to the data list */
+      filterChange(ServicesState.getFilters());
+      ServicesState.filterApplied = false;
+    }
 
     function handleClick(item, e) {
       $state.go('services.details', {serviceId: item.id});


### PR DESCRIPTION
Requests count would now be derived from 3 Request promise arrays for `Pending`, `Approved` and `Denied`.
Each promise array would comprise of 2 promises for the two types of Request -
`ServiceReconfigureRequest` and `ServiceTemplateProvisionRequest`

This change is mainly done due to the API design limitation on how it handles the logical `OR` operation.

https://bugzilla.redhat.com/show_bug.cgi?id=1333942