### PR TITLE
lodash needs to be downgraded to be compatible with angular-patternfly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "angular-ui-router": "~0.2.15",
     "font-awesome": "~4.4.0",
     "jquery": "~2.1.0",
-    "lodash": "~4.12.0",
+    "lodash": "~3.9.0",
     "moment": "~2.10.0",
     "ngprogress": "~1.1.2",
     "ngstorage": "~0.3.10",

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -129,7 +129,7 @@
 
   function resolveRequestPromises(promiseArray, vm, type, lodash, $q) {
     $q.all(promiseArray).then(function(data) {
-      var count = lodash.sumBy(data, 'subcount');
+      var count = lodash.sum(data, 'subcount');
       vm.requestsCount[type] = count;
       vm.requestsCount.total += count;
     });


### PR DESCRIPTION
lodash should be downgraded to v3.9.0 to be compatible with `"angular-patternfly": "~2.3.2"`.

It was upgraded in https://github.com/ManageIQ/manageiq-ui-self_service/pull/51/commits/d2813dfe0a14478d5299942d360cf34d87805f4a for the `.sumBy` call.
The `.sumBy` call has now been replaced with `.sum` which is supported by lodash v3.9.0.
