### PR TITLE
Default sorting filters should always be applied when the list is loaded

### DIFF
--- a/client/app/states/requests/list/list.state.js
+++ b/client/app/states/requests/list/list.state.js
@@ -118,6 +118,8 @@
       /* Apply the filtering to the data list */
       filterChange(RequestsState.getFilters());
       RequestsState.filterApplied = false;
+    } else {
+      applyFilters();
     }
 
     function handleClick(item, e) {

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -137,6 +137,8 @@
       /* Apply the filtering to the data list */
       filterChange(ServicesState.getFilters());
       ServicesState.filterApplied = false;
+    } else {
+      applyFilters();
     }
 
     function handleClick(item, e) {


### PR DESCRIPTION
When the `Services` or `Requests` list is loaded,
(a) the list should always have the default sorting filters applied
(b) number of items in the list must match the number displayed in the Dashboard or the side navigation bar