### PR TITLE
Fix blueprint create / update success flash message

### DIFF
--- a/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
+++ b/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
@@ -76,7 +76,7 @@
 
   /** @ngInject */
   function BlueprintDetailsModalController(action, blueprintId, BlueprintsState, jQuery, serviceCatalogs, serviceDialogs, tenants, $state, // jshint ignore:line
-                                           $modalInstance, CollectionsApi, Notifications) { // jshint ignore:line
+                                           $modalInstance, CollectionsApi, Notifications, sprintf) { // jshint ignore:line
     var vm = this;
 
     if (action === 'create') {
@@ -191,10 +191,11 @@
 
       function saveSuccess() {
         $modalInstance.close();
-        Notifications.success(vm.blueprint.name + __(' was ' + action + 'ed.'));
         if (action === 'create') {
+          Notifications.success(sprintf(__('%s was created.'), vm.blueprint.name));
           $state.go('blueprints.designer', {blueprintId: vm.blueprint.id});
         } else if (action === 'edit') {
+          Notifications.success(sprintf(__('%s was updated.'), vm.blueprint.name));
           $state.go($state.current, {}, {reload: true});
         }
       }


### PR DESCRIPTION
1. we cannot just dynamically construct string inside a gettext invocation
2. 'create' + 'ed' -> 'createed'

Before:
![bp-create-before](https://cloud.githubusercontent.com/assets/6648365/16086867/47b16268-3321-11e6-8cf1-83e83521d46c.jpg)

After:
![bp-create-after](https://cloud.githubusercontent.com/assets/6648365/16086872/4dc735b0-3321-11e6-8058-99c12a0f06f6.jpg)
