### PR TITLE
Simplify creation of blueprint delete confirmation message

### DIFF
--- a/client/app/components/blueprint-delete-modal/blueprint-delete-modal-service.factory.js
+++ b/client/app/components/blueprint-delete-modal/blueprint-delete-modal-service.factory.js
@@ -36,13 +36,6 @@
     var vm = this;
 
     vm.blueprintsList = blueprints;
-
-    if (vm.blueprintsList.length === 1) {
-      vm.delBlueprintsLabel = vm.blueprintsList[0].name + __('?');
-    } else {
-      vm.delBlueprintsLabel = vm.blueprintsList.length + ' ' + __('blueprints?');
-    }
-
     vm.deleteBlueprints = deleteBlueprints;
 
     activate();

--- a/client/app/components/blueprint-delete-modal/blueprint-delete-modal.html
+++ b/client/app/components/blueprint-delete-modal/blueprint-delete-modal.html
@@ -5,7 +5,7 @@
   <h3 class="modal-title">Delete Blueprint</h3>
 </div>
 <div class="modal-body">
-  <h3 translate>Are you sure you want to delete {{vm.delBlueprintsLabel}}</h3>
+  <h3 translate translate-n="vm.blueprintsList.length" translate-plural="Are you sure you want to delete {{$count}} blueprints?">Are you sure you want to delete {{vm.blueprintsList[0].name}}?</h3>
   <span ng-if="vm.blueprintsList.length > 1">
     <a href="#blueprintsList" id="blueprintsListHref" data-toggle="collapse" class="collapsed" translate>Show Blueprint Names</a>
     <div id="blueprintsList" class="collapse">


### PR DESCRIPTION
1. we got rid of __('?'), __('blueprint?') which would be kind of weird to translate
2. we don't construct the confirmation message in two places
3. we reduced the amount of code :-)