### PR TITLE
Fix build step not copying console dependencies and translations

### DIFF
--- a/client/app/services/consoles.service.js
+++ b/client/app/services/consoles.service.js
@@ -78,7 +78,7 @@
     }
 
     function openSpice(results) {
-      var url = '/bower_components/spice-html5-bower/spiceHTML5/spice_auto.html' +
+      var url = '/self_service/bower_components/spice-html5-bower/spiceHTML5/spice_auto.html' +
         '?host=' + $location.host() +
         '&port=' + $location.port() +
         '&path=' + results.url +
@@ -90,7 +90,7 @@
     }
 
     function openVnc(results) {
-      var url = '/bower_components/no-vnc/vnc_auto.html' +
+      var url = '/self_service/bower_components/no-vnc/vnc_auto.html' +
         '?host=' + $location.host() +
         '&port=' + $location.port() +
         '&path=' + results.url +

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -404,7 +404,7 @@ module.exports = (function() {
   };
 
   config.gettextCopy = {
-    inputs: 'client/gettext/json/*.json',
+    inputs: 'client/gettext/json/**/*.json',
     outputDir: build + 'gettext/json/',
   };
 

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -408,6 +408,17 @@ module.exports = (function() {
     outputDir: build + 'gettext/json/',
   };
 
+  config.consoleCopy = [
+    {
+      input: 'bower_components/no-vnc/**/*',
+      output: build + 'bower_components/no-vnc',
+    },
+    {
+      input: 'bower_components/spice-html5-bower/**/*',
+      output: build + 'bower_components/spice-html5-bower',
+    },
+  ];
+
   // task bump: Revs the package and bower files
   config.bump = {
     packages: [

--- a/gulp/tasks/console-copy.js
+++ b/gulp/tasks/console-copy.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var log = require('../utils/log');
+var merge = require('merge-stream');
+
+module.exports = function(gulp, options) {
+  var config = require('../config')[options.key || 'consoleCopy'];
+
+  return task;
+
+  function task() {
+    if (options.verbose) {
+      log('Copying console dependencies to build dir');
+    }
+
+    var merged = merge();
+    config.forEach(function(config) {
+      var stream = gulp.src(config.input)
+        .pipe(gulp.dest(config.output));
+
+      merged.add(stream);
+    });
+
+    return merged;
+  }
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,13 +47,14 @@ gulp.task('dev-imgs', task('images', {key: 'devImgs'}));
 gulp.task('gettext-extract', task('gettext-extract'));
 gulp.task('gettext-compile', task('gettext-compile'));
 gulp.task('gettext-copy', task('gettext-copy'));
+gulp.task('console-copy', task('console-copy'));
 
 /**
  * Build tasks
  */
 gulp.task('inject', ['wiredep', 'sass', 'templatecache'], task('inject'));
 gulp.task('optimize', ['inject'], task('optimize'));
-gulp.task('build', ['optimize', 'images', 'imgs', 'skin-images', 'fonts', 'gettext-copy'], task('build'));
+gulp.task('build', ['optimize', 'images', 'imgs', 'skin-images', 'fonts', 'gettext-copy', 'console-copy'], task('build'));
 gulp.task('build-specs', ['templatecache'], task('buildSpecs'));
 
 /**

--- a/server/app.js
+++ b/server/app.js
@@ -79,6 +79,8 @@ switch (environment) {
     router.use('/app/*', function(req, res) {
       four0four.send404(req, res);
     });
+    // makes both /bower_components and /self_service/bower_components/ work
+    router.use(express.static('./'));
     // Any deep link calls should return index.html
     app.use('/*', express.static('./client/index.html'));
     break;


### PR DESCRIPTION
Right now, neither the gettext translations nor the html templates for spice & vnc consoles are properly copied during the `gulp build` step, so neither actually works in the appliance now.

This fixes `gulp gettext-copy` by fixing the path selector (one more dir level now), and adds `gulp console-copy` to copy the console templates and their dependencies to the right place.

Also adjusted the console code to find the template using the full path, including `/self_service` and updated the devel-mode server to actually cope with such a path too.

Assuming `darga/yes` since without this, consoles and i18n won't work in SSUI..

Fixes #61 
https://bugzilla.redhat.com/show_bug.cgi?id=1347312
https://bugzilla.redhat.com/show_bug.cgi?id=1347319

@AparnaKarve could you review please?