### PR TITLE
npm-shrinkwrap - force gulp-header to 1.8.2 for gulp-angular-templatecache

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "gulp-header": {
+      "version": "1.8.2",
+      "from": "gulp-angular-templatecache"
+    }
+  }
+}


### PR DESCRIPTION
this is to fix tracker1/gulp-header#37:
  * gulp-angular-templatecache depends on gulp-header 1.x
  * gulp-header 1.8.3 tries to lstat before writing and fails

which leads `gulp templatecache` to fail with ENOENT on the file it's trying to write to.. :)

@simaishi , @Fryguy ..