### PR TITLE
downgrade karma to resolve dependency issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "gulp-util": "^3.0.4",
     "jscs": "^2.7.0",
     "jshint-stylish": "^1.0.1",
-    "karma": "^0.13.0",
+    "karma": "^0.12.0",
     "karma-chai": "^0.1.0",
     "karma-chai-sinon": "^0.1.4",
     "karma-coverage": "^0.2.7",


### PR DESCRIPTION
<pre><code>
# npm install
npm WARN package.json gulp-minify-css@1.2.4 No repository field.
npm WARN package.json gulp-minify-html@1.0.6 No repository field.
npm WARN cannot run in wd manageiq-ui-self_service@0.0.1 bower install -F (wd=/root/ws/miq/manageiq-ui-self_service)
npm WARN cannot run in wd manageiq-ui-self_service@0.0.1 gulp build (wd=/root/ws/miq/manageiq-ui-self_service)
npm ERR! peerinvalid The package karma does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer gulp-karma@0.0.4 wants karma@>=0.10 <=0.13
npm ERR! peerinvalid Peer karma-chai@0.1.0 wants karma@>=0.10.9
npm ERR! peerinvalid Peer karma-chai-sinon@0.1.5 wants karma@>=0.6
npm ERR! peerinvalid Peer karma-coverage@0.2.7 wants karma@>=0.9
npm ERR! peerinvalid Peer karma-growl-reporter@0.1.1 wants karma@>=0.9
npm ERR! peerinvalid Peer karma-mocha@0.1.10 wants karma@>=0.12.8
npm ERR! peerinvalid Peer karma-phantomjs-launcher@0.1.4 wants karma@>=0.9
npm ERR! peerinvalid Peer karma-sinon@1.0.5 wants karma@>=0.10

npm ERR! System Linux 3.10.0-327.18.2.el7.x86_64
npm ERR! command "node" "/usr/bin/npm" "install"
npm ERR! cwd /root/ws/miq/manageiq-ui-self_service
npm ERR! node -v v0.10.42
npm ERR! npm -v 1.3.6
npm ERR! code EPEERINVALID
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /root/ws/miq/manageiq-ui-self_service/npm-debug.log
npm ERR! not ok code 0
</code></pre>

This issue is caused by karma, the version of karma in package.json is defined as follow:
"karma": "^0.13.0",
karma 0.13.x has dependency error with others now, downgrade to 0.12.x will resolve it. 