### PR TITLE
Updated version for npm in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Self Service UI for the [ManageIQ](http://github.com/ManageIQ/manageiq) proj
   `git clone git@github.com:ManageIQ/manageiq-ui-self_service.git`
 - `cd manageiq-ui-self_service`
 - `bundle install`
-- `npm install`
+- `npm install` *(at least version 3.0)*
 
 ## Development
 


### PR DESCRIPTION
With older version, this issue happens:

```

[16:34:00] *** nodemon started
module.js:327
    throw err;
    ^

Error: Cannot find module 'express'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/rblanco/devel/manageiq-ssui/server/app.js:4:15)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)

```

@himdel 