### PR TITLE
Fix IE11 - CollectionsApi - URI-escape right-side values in query string

### DIFF
--- a/client/app/resources/collections-api.factory.js
+++ b/client/app/resources/collections-api.factory.js
@@ -21,7 +21,7 @@
         return MockData.retrieveMockData(collection);
       } else {
         return $http.get(url + buildQuery(options), buildConfig(options))
-            .then(handleSuccess);
+          .then(handleSuccess);
       }
 
       function handleSuccess(response) {
@@ -61,35 +61,35 @@
         if (angular.isArray(options.expand)) {
           options.expand = options.expand.join(',');
         }
-        params.push('expand=' + options.expand);
+        params.push('expand=' + encodeURIComponent(options.expand));
       }
 
       if (options.attributes) {
         if (angular.isArray(options.attributes)) {
           options.attributes = options.attributes.join(',');
         }
-        params.push('attributes=' + options.attributes);
+        params.push('attributes=' + encodeURIComponent(options.attributes));
       }
 
       if (options.decorators) {
         if (angular.isArray(options.decorators)) {
           options.decorators = options.decorators.join(',');
         }
-        params.push('decorators=' + options.decorators);
+        params.push('decorators=' + encodeURIComponent(options.decorators));
       }
 
       if (options.filter) {
         angular.forEach(options.filter, function(filter) {
-          params.push('filter[]=' + filter);
+          params.push('filter[]=' + encodeURIComponent(filter));
         });
       }
 
       if (options.sort_by) {
-        params.push('sort_by=' + options.sort_by);
+        params.push('sort_by=' + encodeURIComponent(options.sort_by));
       }
 
       if (options.sort_options) {
-        params.push('sort_options=' + options.sort_options);
+        params.push('sort_options=' + encodeURIComponent(options.sort_options));
       }
 
       if (params.length) {


### PR DESCRIPTION
This makes `CollectionsApi` escape all its query-string arguments - without this, you can get an url like

    /api/services?filters[]=service_id=nil&filter[]=retires_on>=2016-07-14&filter[]=retires_on<=2016-08-13

instead of

    /api/services?filters[]=service_id%3Dnil&filter[]=retires_on%3E%3D2016-07-14&filter[]=retires_on%3C%3D2016-08-13

And while the first url works just fine in chrome, it does return a 400 for IE11, meaning it's impossible to log in from IE..

@dclarizio we *may* want a BZ and darga/yes for this, since we *are* supposed to support IE11 in darga, right?