### PR TITLE
Language switcher

### DIFF
--- a/client/app/components/language-switcher/language-switcher.directive.js
+++ b/client/app/components/language-switcher/language-switcher.directive.js
@@ -20,7 +20,7 @@
     return directive;
 
     /** @ngInject */
-    function LanguageSwitcherController(gettextCatalog, Language, lodash) {
+    function LanguageSwitcherController($scope, gettextCatalog, Language, lodash) {
       var vm = this;
       vm.mode = vm.mode || 'menu';
 
@@ -34,6 +34,14 @@
         delete hardcoded._user_;
       } else {
         vm.chosen = Language.chosen = { code: '_user_' };
+
+        $scope.$watch('vm.chosen.code', function(val) {
+          if (!val || (val === '_user_')) {
+            val = "en";
+          }
+
+          Language.setLocale(val);
+        });
       }
 
       Language.ready

--- a/client/app/components/language-switcher/language-switcher.directive.js
+++ b/client/app/components/language-switcher/language-switcher.directive.js
@@ -8,7 +8,9 @@
   function LanguageSwitcherDirective() {
     var directive = {
       restrict: 'AE',
-      scope: {},
+      scope: {
+        mode: '@?',
+      },
       templateUrl: 'app/components/language-switcher/language-switcher.html',
       controller: LanguageSwitcherController,
       controllerAs: 'vm',
@@ -20,11 +22,19 @@
     /** @ngInject */
     function LanguageSwitcherController(gettextCatalog, Language, lodash) {
       var vm = this;
+      vm.mode = vm.mode || 'menu';
 
       var hardcoded = {
+        "_user_": __("User Default"),
         "_browser_": __("Browser Default"),
       };
       vm.available = hardcoded;
+
+      if (vm.mode === 'menu') {
+        delete hardcoded._user_;
+      } else {
+        vm.chosen = Language.chosen = { code: '_user_' };
+      }
 
       Language.ready
         .then(function(available) {

--- a/client/app/components/language-switcher/language-switcher.directive.js
+++ b/client/app/components/language-switcher/language-switcher.directive.js
@@ -1,0 +1,39 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .directive('languageSwitcher', LanguageSwitcherDirective);
+
+  /** @ngInject */
+  function LanguageSwitcherDirective() {
+    var directive = {
+      restrict: 'AE',
+      scope: {},
+      templateUrl: 'app/components/language-switcher/language-switcher.html',
+      controller: LanguageSwitcherController,
+      controllerAs: 'vm',
+      bindToController: true
+    };
+
+    return directive;
+
+    /** @ngInject */
+    function LanguageSwitcherController(gettextCatalog, Language, lodash) {
+      var vm = this;
+
+      var hardcoded = {
+        "_browser_": __("Browser Default"),
+      };
+      vm.available = hardcoded;
+
+      Language.ready
+        .then(function(available) {
+          vm.available = lodash.extend({}, hardcoded, available);
+        });
+
+      vm.switch = function(code) {
+        Language.setLocale(code);
+      };
+    }
+  }
+})();

--- a/client/app/components/language-switcher/language-switcher.directive.js
+++ b/client/app/components/language-switcher/language-switcher.directive.js
@@ -43,6 +43,7 @@
 
       vm.switch = function(code) {
         Language.setLocale(code);
+        Language.save(code);
       };
     }
   }

--- a/client/app/components/language-switcher/language-switcher.directive.js
+++ b/client/app/components/language-switcher/language-switcher.directive.js
@@ -20,7 +20,7 @@
     return directive;
 
     /** @ngInject */
-    function LanguageSwitcherController($scope, gettextCatalog, Language, lodash) {
+    function LanguageSwitcherController($scope, gettextCatalog, Language, lodash, $state) {
       var vm = this;
       vm.mode = vm.mode || 'menu';
 
@@ -52,6 +52,7 @@
       vm.switch = function(code) {
         Language.setLocale(code);
         Language.save(code);
+        $state.reload();
       };
     }
   }

--- a/client/app/components/language-switcher/language-switcher.html
+++ b/client/app/components/language-switcher/language-switcher.html
@@ -1,0 +1,12 @@
+<a href="#">
+  <span translate>
+    Switch Language:
+  </span>
+</a>
+<ul class="dropdown-menu scrollable-menu">
+  <li ng-repeat="(code, name) in vm.available">
+    <a href="#" ng-click="vm.switch(code)">
+      {{name || code}}
+    </a>
+  </li>
+</ul>

--- a/client/app/components/language-switcher/language-switcher.html
+++ b/client/app/components/language-switcher/language-switcher.html
@@ -1,12 +1,14 @@
-<a href="#">
+<a ng-if="vm.mode == 'menu'" href="#">
   <span translate>
     Switch Language:
   </span>
 </a>
-<ul class="dropdown-menu scrollable-menu">
+<ul ng-if="vm.mode == 'menu'" class="dropdown-menu scrollable-menu">
   <li ng-repeat="(code, name) in vm.available">
     <a href="#" ng-click="vm.switch(code)">
       {{name || code}}
     </a>
   </li>
 </ul>
+
+<select ng-if="vm.mode == 'select'" pf-select ng-model="vm.chosen.code" ng-options="code as (name || code) for (code, name) in vm.available"></select>

--- a/client/app/components/navigation/header-nav.html
+++ b/client/app/components/navigation/header-nav.html
@@ -62,6 +62,8 @@
           </li>
           <!-- /Group switcher -->
 
+          <li class="dropdown-submenu pull-left" language-switcher></li>
+
           <li class="action divider"></li>
 
           <li class="action"><a ui-sref="logout" translate>Logout</a></li>

--- a/client/app/config/authorization.config.js
+++ b/client/app/config/authorization.config.js
@@ -56,7 +56,7 @@
   }
 
   /** @ngInject */
-  function init($rootScope, $state, Session, jQuery, $sessionStorage, logger) {
+  function init($rootScope, $state, Session, jQuery, $sessionStorage, logger, Language) {
     $rootScope.$on('$stateChangeStart', changeStart);
     $rootScope.$on('$stateChangeError', changeError);
     $rootScope.$on('$stateChangeSuccess', changeSuccess);
@@ -88,6 +88,7 @@
       });
 
       Session.loadUser()
+        .then(Language.onReload)
         .then(rbacReloadOrLogin(toState, toParams))
         .catch(badUser);
     }

--- a/client/app/config/gettext.config.js
+++ b/client/app/config/gettext.config.js
@@ -13,7 +13,9 @@
       if (lang) {
         lang = lang.replace('_', '-');
         gettextCatalog.setCurrentLanguage(lang);
-        gettextCatalog.loadRemote("gettext/json/" + lang + "/manageiq-ui-self_service.json");
+        if (lang !== 'en') {
+          gettextCatalog.loadRemote("gettext/json/" + lang + "/manageiq-ui-self_service.json");
+        }
       }
     };
 

--- a/client/app/core/core.module.spec.js
+++ b/client/app/core/core.module.spec.js
@@ -1,0 +1,11 @@
+(function() {
+  'use strict';
+
+  angular.module('app.core')
+    .run(mock);
+
+  function mock($httpBackend) {
+    $httpBackend.when('GET', /available_languages.json/)
+      .respond({});
+  }
+})();

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -5,22 +5,75 @@
     .factory('Language', LanguageFactory);
 
   /** @ngInject */
-  function LanguageFactory(gettextCatalog) {
+  function LanguageFactory($http, $q, gettextCatalog, lodash) {
+    var availableAvailable = $q.defer();
     var service = {
+      available: {
+        'en': 'English',  // not translated on purpose
+      },
+      ready: availableAvailable.promise,
       onLogin: onLogin,
       onReload: onReload,
+      setLocale: setLocale,
     };
+
+    init();
 
     return service;
 
+    function init() {
+      $http.get('gettext/json/available_languages.json')
+      .then(function(response) {
+        lodash.extend(service.available, response.data);
+        availableAvailable.resolve(service.available);
+      });
+    }
+
+    function setLocale(code) {
+      gettextCatalog.loadAndSet(code);
+
+      return code;
+    }
+
+    function getLocale(data) {
+      return data
+        && data.settings
+        && data.settings.locale;
+    }
+
     function onLogin(data) {
-      var locale = data.settings && data.settings.locale;
-      gettextCatalog.loadAndSet(locale);
+      var code = getLocale(data);
+      setLocale(code);
     }
 
     function onReload(data) {
-      var locale = data.settings && data.settings.locale;
-      gettextCatalog.loadAndSet(locale);
+      var code = getLocale(data);
+      setLocale(code);
+    }
+
+    function save(code) {
+      if (!service.user_href) {
+        console.error('Trying to save language selection without a valid user_href');
+
+        return;
+      }
+
+      if (code === '_browser_') {
+        code = null;
+      }
+
+      return $http.post(service.user_href, {
+        action: 'edit',
+        resource: {
+          settings: {
+            ui_self_service: {
+              display: {
+                locale: code,
+              },
+            },
+          },
+        },
+      });
     }
   }
 })();

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -172,7 +172,10 @@
         return;
       }
 
-      state.sort.currentField = lodash.find(fields, { id: current.id }) || current;
+      var found = lodash.find(fields, { id: current.id }) || current;
+
+      // can't just replace currentField, the original instance stays inside pf-sort
+      state.sort.currentField.title = found.title;
     }
   }
 })();

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -5,7 +5,7 @@
     .factory('Language', LanguageFactory);
 
   /** @ngInject */
-  function LanguageFactory($http, $q, gettextCatalog, lodash) {
+  function LanguageFactory($http, $q, gettextCatalog, lodash, Text) {
     var availableAvailable = $q.defer();
     var service = {
       available: {
@@ -64,6 +64,9 @@
       }
 
       gettextCatalog.loadAndSet(code);
+      if (Text.init) {
+        Text.init();
+      }
 
       return code;
     }

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -17,6 +17,8 @@
       chosen: {
         code: null,
       },
+      save: save,
+      user_href: null,
       setLocale: setLocale,
     };
 
@@ -41,21 +43,32 @@
     function getLocale(data) {
       return data
         && data.settings
-        && data.settings.locale;
+        && data.settings.ui_self_service
+        && data.settings.ui_self_service.display
+        && data.settings.ui_self_service.display.locale;
+    }
+
+    function setUser(data) {
+      service.user_href = data.identity.user_href.replace(/^.*?\/api\//, '/api/');
     }
 
     function onLogin(data) {
+      setUser(data);
+
       var code = 'en';
       if (!service.chosen.code || (service.chosen.code === '_user_')) {
         code = getLocale(data);
       } else {
         code = service.chosen.code;
+        save(code);
       }
 
       setLocale(code);
     }
 
     function onReload(data) {
+      setUser(data);
+
       var code = getLocale(data);
       setLocale(code);
     }

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -12,6 +12,7 @@
         'en': 'English',  // not translated on purpose
       },
       ready: availableAvailable.promise,
+      browser: browser,
       onLogin: onLogin,
       onReload: onReload,
       chosen: {
@@ -32,6 +33,28 @@
         lodash.extend(service.available, response.data);
         availableAvailable.resolve(service.available);
       });
+    }
+
+    // returns a list of user's preferred languages, in order
+    function browser() {
+      var ary = [];
+
+      // the standard
+      if (lodash.isArray(window.navigator.languages)) {
+        ary = lodash.slice(window.navigator.languages);
+      }
+
+      // IE 11 and older browers
+      if (window.navigator.language) {
+        ary.push(window.navigator.language);
+      }
+
+      // IE<11
+      if (window.navigator.userLanguage) {
+        ary.push(window.navigator.userLanguage);
+      }
+
+      return lodash.uniq(ary);
     }
 
     function setLocale(code) {

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -1,0 +1,26 @@
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('Language', LanguageFactory);
+
+  /** @ngInject */
+  function LanguageFactory(gettextCatalog) {
+    var service = {
+      onLogin: onLogin,
+      onReload: onReload,
+    };
+
+    return service;
+
+    function onLogin(data) {
+      var locale = data.settings && data.settings.locale;
+      gettextCatalog.loadAndSet(locale);
+    }
+
+    function onReload(data) {
+      var locale = data.settings && data.settings.locale;
+      gettextCatalog.loadAndSet(locale);
+    }
+  }
+})();

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -14,6 +14,9 @@
       ready: availableAvailable.promise,
       onLogin: onLogin,
       onReload: onReload,
+      chosen: {
+        code: null,
+      },
       setLocale: setLocale,
     };
 
@@ -42,7 +45,13 @@
     }
 
     function onLogin(data) {
-      var code = getLocale(data);
+      var code = 'en';
+      if (!service.chosen.code || (service.chosen.code === '_user_')) {
+        code = getLocale(data);
+      } else {
+        code = service.chosen.code;
+      }
+
       setLocale(code);
     }
 

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -22,6 +22,7 @@
       match: match,
       user_href: null,
       setLocale: setLocale,
+      fixState: fixState,
     };
 
     init();
@@ -161,6 +162,17 @@
       }
 
       return 'en';
+    }
+
+    function fixState(state, toolbarConfig) {
+      var fields = toolbarConfig.sortConfig.fields;
+      var current = state.sort.currentField;
+
+      if (!current || !current.id) {
+        return;
+      }
+
+      state.sort.currentField = lodash.find(fields, { id: current.id }) || current;
     }
   }
 })();

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -5,7 +5,7 @@
     .factory('Language', LanguageFactory);
 
   /** @ngInject */
-  function LanguageFactory($http, $q, gettextCatalog, lodash, Text) {
+  function LanguageFactory($http, $q, gettextCatalog, lodash) {
     var availableAvailable = $q.defer();
     var service = {
       available: {
@@ -65,9 +65,6 @@
       }
 
       gettextCatalog.loadAndSet(code);
-      if (Text.init) {
-        Text.init();
-      }
 
       return code;
     }

--- a/client/app/services/language.service.js
+++ b/client/app/services/language.service.js
@@ -19,6 +19,7 @@
         code: null,
       },
       save: save,
+      match: match,
       user_href: null,
       setLocale: setLocale,
     };
@@ -58,6 +59,10 @@
     }
 
     function setLocale(code) {
+      if (!code || (code === '_browser_')) {
+        code = service.match(service.available, service.browser());
+      }
+
       gettextCatalog.loadAndSet(code);
 
       return code;
@@ -119,6 +124,40 @@
           },
         },
       });
+    }
+
+    // returns the best match from available
+    function match(available, requested) {
+      var shorten = function(str) {
+        return {
+          orig: str,
+          short: str.replace(/[-_].*$/, ''),
+        };
+      };
+
+      var short = {
+        available: lodash.keys(available).map(shorten),
+        requested: requested.map(shorten),
+      };
+
+      for (var k in short.requested) {
+        /* jshint -W089, -W083 */
+        var r = short.requested[k];
+
+        var match = lodash.find(short.available, function(a) {
+          // try exact match first
+          return a.orig.toLowerCase() === r.orig.toLowerCase();
+        }) || lodash.find(short.available, function(a) {
+          // lowercase, only language code match second
+          return a.short.toLowerCase() === r.short.toLowerCase();
+        });
+
+        if (match) {
+          return match.orig;
+        }
+      }
+
+      return 'en';
     }
   }
 })();

--- a/client/app/services/language.service.spec.js
+++ b/client/app/services/language.service.spec.js
@@ -1,0 +1,21 @@
+/* jshint -W117, -W030 */
+describe('app.services.Language', function() {
+  beforeEach(function() {
+    module('app.states', 'app.services', 'gettext', bard.fakeToastr);
+    bard.inject('Language');
+  });
+
+  describe('#match', function() {
+    it('matches short available with long accepted', function() {
+      var available = {'ja': '', 'en': '', 'fr': ''};
+      var accepted = ['fr-FR', 'en'];
+      expect(Language.match(available, accepted)).to.eq('fr');
+    });
+
+    it('matches long available with short accepted', function() {
+      var available = {'ja-JP': '', 'en': '', 'fr-FR': ''};
+      var accepted = ['fr', 'en'];
+      expect(Language.match(available, accepted)).to.eq('fr-FR');
+    });
+  });
+});

--- a/client/app/services/marketplace-state.service.js
+++ b/client/app/services/marketplace-state.service.js
@@ -6,13 +6,13 @@
 
   /** @ngInject */
   function MarketplaceStateFactory() {
-    var service = {};   
+    var service = {};
 
     service.sort = {
       isAscending: true,
-      currentField: { id: 'name', title:  'Name', sortType: 'alpha' }
+      currentField: { id: 'name', title: __('Name'), sortType: 'alpha' }
     };
-    
+
     service.filters = [];
 
     service.setSort = function(currentField, isAscending) {
@@ -23,7 +23,7 @@
     service.getSort = function() {
       return service.sort;
     };
-    
+
     service.setFilters = function(filterArray) {
       service.filters = filterArray;
     };

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -7,13 +7,13 @@
 
   /** @ngInject */
   function ServicesStateFactory() {
-    var service = {};   
+    var service = {};
 
     service.sort = {
       isAscending: true,
       currentField: { id: 'name', title: __('Name'), sortType: 'alpha' }
     };
-    
+
     service.filters = [];
 
     service.setSort = function(currentField, isAscending) {

--- a/client/app/services/session.service.js
+++ b/client/app/services/session.service.js
@@ -56,8 +56,7 @@
           currentUser(response.data.identity);
           setRBAC(response.data.authorization.product_features);
 
-          var locale = response.data.settings && response.data.settings.locale;
-          gettextCatalog.loadAndSet(locale);
+          return response.data;
         });
     }
 

--- a/client/app/skin/skin.module.js
+++ b/client/app/skin/skin.module.js
@@ -6,7 +6,7 @@
     .config(configure);
 
   /** @ngInject */
-  function Text($timeout) {
+  function Text($timeout, $rootScope) {
     var o = {
       app: {
         name: null,
@@ -14,13 +14,14 @@
       login: {
         brand: null,
       },
-      init: init,
     };
 
     function init() {
       o.app.name = __('ManageIQ Self Service');
       o.login.brand = '<strong>ManageIQ</strong> ' + __('Self Service');
     }
+
+    $rootScope.$on('gettextLanguageChanged', init);
 
     return o;
   }

--- a/client/app/skin/skin.module.js
+++ b/client/app/skin/skin.module.js
@@ -2,17 +2,28 @@
   'use strict';
 
   angular.module('app.skin', [])
-    .factory('Text', function() {
-      return {
-        app: {
-          name: __('ManageIQ Self Service'),
-        },
-        login: {
-          brand: '<strong>ManageIQ</strong> ' + __('Self Service'),
-        },
-      };
-    })
+    .factory('Text', Text)
     .config(configure);
+
+  /** @ngInject */
+  function Text($timeout) {
+    var o = {
+      app: {
+        name: null,
+      },
+      login: {
+        brand: null,
+      },
+      init: init,
+    };
+
+    function init() {
+      o.app.name = __('ManageIQ Self Service');
+      o.login.brand = '<strong>ManageIQ</strong> ' + __('Self Service');
+    }
+
+    return o;
+  }
 
   /** @ngInject */
   function configure(routerHelperProvider, exceptionHandlerProvider) {

--- a/client/app/states/blueprints/list/list.state.js
+++ b/client/app/states/blueprints/list/list.state.js
@@ -32,7 +32,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, blueprints, BlueprintsState, BlueprintDetailsModal, BlueprintDeleteModal, $filter, $rootScope) {
+  function StateController($state, blueprints, BlueprintsState, BlueprintDetailsModal, BlueprintDeleteModal, $filter, $rootScope, Language) {
     /* jshint validthis: true */
     var vm = this;
 
@@ -289,5 +289,7 @@
 
       return false;
     }
+
+    Language.fixState(BlueprintsState, vm.toolbarConfig);
   }
 })();

--- a/client/app/states/login/login.html
+++ b/client/app/states/login/login.html
@@ -25,16 +25,6 @@
           </div>
           <!--/.form-group-*-->
           <div class="form-group">
-            <!-- Non-functioning controls
-            <div class="col-xs-8 col-sm-offset-2 col-sm-6 col-md-offset-2 col-md-6">
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" tabindex="3"> Remember username
-                </label>
-              </div>
-              <span class="help-block"> Forgot <a href="#" tabindex="5">username</a> or <a href="#" tabindex="6">password</a>?</span>
-            </div>
-            -->
             <div class="col-xs-4 col-sm-4 col-md-4 pull-right submit">
               <button type="submit" class="btn btn-primary btn-lg" tabindex="4" translate>Log In</button>
             </div>

--- a/client/app/states/login/login.html
+++ b/client/app/states/login/login.html
@@ -25,6 +25,11 @@
           </div>
           <!--/.form-group-*-->
           <div class="form-group">
+            <label class="col-sm-2 col-md-2 control-label" translate>Language</label>
+            <div class="col-xs-8 col-sm-6 col-md-6">
+             <language-switcher mode="select"></language-switcher>
+            </div>
+
             <div class="col-xs-4 col-sm-4 col-md-4 pull-right submit">
               <button type="submit" class="btn btn-primary btn-lg" tabindex="4" translate>Log In</button>
             </div>

--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -26,7 +26,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, CollectionsApi, Session, $rootScope, Notifications) {
+  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, CollectionsApi, Session, $rootScope, Notifications, Language) {
     var vm = this;
 
     vm.title = __('Login');
@@ -50,6 +50,7 @@
 
       return AuthenticationApi.login(vm.credentials.login, vm.credentials.password)
         .then(Session.loadUser)
+        .then(Language.onLogin)
         .then(function() {
           if (Session.activeNavigationFeatures()) {
             if (angular.isDefined($rootScope.notifications) && $rootScope.notifications.data.length > 0) {

--- a/client/app/states/marketplace/list/list.state.js
+++ b/client/app/states/marketplace/list/list.state.js
@@ -45,7 +45,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, serviceTemplates, serviceCatalogs, MarketplaceState) {
+  function StateController($state, serviceTemplates, serviceCatalogs, MarketplaceState, Language) {
     var vm = this;
 
     vm.title = __('Service Catalog');
@@ -201,5 +201,7 @@
 
       return compValue;
     }
+
+    Language.fixState(MarketplaceState, vm.toolbarConfig);
   }
 })();

--- a/client/app/states/requests/list/list.html
+++ b/client/app/states/requests/list/list.html
@@ -1,5 +1,5 @@
 <tabset>
-  <tab heading="My Requests">
+  <tab heading="{{'My Requests' | translate}}">
     <div class="row">
       <div class="col-md-12 ">
         <div pf-toolbar id="requestToolbar" config="vm.toolbarConfig"></div>
@@ -12,7 +12,7 @@
       <request-list items="vm.requestsList" config="vm.listConfig"></request-list>
     </div>
   </tab>
-  <tab heading="My Orders">
+  <tab heading="{{'My Orders' | translate}}">
     <div class="row">
       <div class="col-md-12 ">
         <div pf-toolbar config="vm.orderToolbarConfig"></div>

--- a/client/app/states/requests/list/list.state.js
+++ b/client/app/states/requests/list/list.state.js
@@ -43,7 +43,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, requests, orders, RequestsState, OrdersState, $filter, $rootScope, lodash) {
+  function StateController($state, requests, orders, RequestsState, OrdersState, $filter, $rootScope, lodash, Language) {
     var vm = this;
 
     vm.title = __('Request List');
@@ -356,5 +356,8 @@
 
       return false;
     }
+
+    Language.fixState(RequestsState, vm.toolbarConfig);
+    Language.fixState(OrdersState, vm.orderToolbarConfig);
   }
 })();

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -34,7 +34,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, services, ServicesState, $filter, $rootScope) {
+  function StateController($state, services, ServicesState, $filter, $rootScope, Language) {
     /* jshint validthis: true */
     var vm = this;
 
@@ -267,5 +267,7 @@
 
       return false;
     }
+
+    Language.fixState(ServicesState, vm.toolbarConfig);
   }
 })();

--- a/client/app/states/states.module.spec.js
+++ b/client/app/states/states.module.spec.js
@@ -1,0 +1,11 @@
+(function() {
+  'use strict';
+
+  angular.module('app.states')
+    .run(mock);
+
+  function mock($httpBackend) {
+    $httpBackend.when('GET', /available_languages.json/)
+      .respond({});
+  }
+})();

--- a/client/index.html
+++ b/client/index.html
@@ -168,6 +168,7 @@
   <script src="/client/app/services/blueprints-state.service.js"></script>
   <script src="/client/app/services/consoles.service.js"></script>
   <script src="/client/app/services/dialog-field-refresh.service.js"></script>
+  <script src="/client/app/services/language.service.js"></script>
   <script src="/client/app/services/marketplace-state.service.js"></script>
   <script src="/client/app/services/messages.service.js"></script>
   <script src="/client/app/services/navcounts.service.js"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -145,6 +145,7 @@
   <script src="/client/app/components/flowchart/mouse_capture_service.js"></script>
   <script src="/client/app/components/flowchart/svg_class.js"></script>
   <script src="/client/app/components/footer/footer-content.directive.js"></script>
+  <script src="/client/app/components/language-switcher/language-switcher.directive.js"></script>
   <script src="/client/app/components/main-content/main-content.directive.js"></script>
   <script src="/client/app/components/navigation/header-nav.directive.js"></script>
   <script src="/client/app/components/navigation/sidebar-nav.directive.js"></script>


### PR DESCRIPTION
This adds a language switcher component, both in the user's menu, and on the login screen.

![i18n-switch-login](https://cloud.githubusercontent.com/assets/289743/16950345/6225ccd0-4daf-11e6-808d-921629c681a6.png)

The login screen defaults to `User Default` meaning whatever the user has saved, but any choice is saved for the next time.

![i18n-switch-menu](https://cloud.githubusercontent.com/assets/289743/16950346/63212af8-4daf-11e6-8362-ea1bda6ab1ea.png)

The menu switcher changes the language immediately, and saves..


The names of the languages get generated from the translations, so while testing the PR, short names (en, fr, es, ..) may appear instead.. The screenshots were done using this `available_languages.json`: `
{"de-DE":"Deutsch","es":"Español","fr":"Français","ja":"日本語","ru":"ру́сский язы́к","sk":"Slovensky","tr":"Türkçe","zh-CN":"中文","zh-Hans-CN":"汉族"}`

WIP:
   * [x] load a list of available languages from the json (https://github.com/ManageIQ/manageiq-ui-self_service/pull/77)
   * [x] a menu component showing the list of languages, and switching
   * [x] the same for login screen
   * [x] save the settings via the API (https://github.com/ManageIQ/manageiq/pull/9801)
   * [x] load the settings from the API (when "User Default" selected)
   * [x] detect the browser-default language
   * [x] pick the right language when browser-default (so that `browserPreferred=[ "fr-FR" ]; available=[ "fr" ]` actually matches `"fr"`) (same logic as [fastgettext](https://github.com/grosser/fast_gettext/blob/master/lib/fast_gettext/storage.rb#L130))
   * [x] commit cleanup, etc.
   * [x] trigger a state reload after switching - so that one-time bound translate strings can work too
   * [x] switch language immediately on login screen
   * [x] going back to login screen should reset the language (to English or browser-default)
   * [x] bug: on my services page, switching from something to English hangs the tab
   * [x] unexpanded selectpickers keep the last translation's version (but the options are fine)

https://bugzilla.redhat.com/show_bug.cgi?id=1356254
https://bugzilla.redhat.com/show_bug.cgi?id=1356256