### PR TITLE
Fix gulp ECMDERR on older node, by forcing plato to 1.4.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "node-notifier": "^4.1.2",
     "phantomjs": "^1.9.16",
     "phantomjs-polyfill": "0.0.1",
-    "plato": "^1.4.0",
+    "plato": "~1.4.0",
     "q": "^1.2.0",
     "request": "^2.55.0",
     "sinon": "^1.14.0",


### PR DESCRIPTION
plato 1.6.0 recently came out, and brought in a dependency on strip-bom 3.0.0 (via eslint), which needs node 4+

This forces plato to 1.4.0 which has no such dependencies.

This needs to be `darga/yes` because build failures..

Closes #85 