### PR TITLE
i18n: Do not translate "Self Service"

### DIFF
--- a/client/app/skin/skin.module.js
+++ b/client/app/skin/skin.module.js
@@ -1,30 +1,18 @@
 (function() {
   'use strict';
 
+  var text = {
+    app: {
+      name: 'ManageIQ Self Service',
+    },
+    login: {
+      brand: '<strong>ManageIQ</strong> Self Service',
+    },
+  };
+
   angular.module('app.skin', [])
-    .factory('Text', Text)
+    .constant('Text', text)
     .config(configure);
-
-  /** @ngInject */
-  function Text($timeout, $rootScope) {
-    var o = {
-      app: {
-        name: null,
-      },
-      login: {
-        brand: null,
-      },
-    };
-
-    function init() {
-      o.app.name = __('ManageIQ Self Service');
-      o.login.brand = '<strong>ManageIQ</strong> ' + __('Self Service');
-    }
-
-    $rootScope.$on('gettextLanguageChanged', init);
-
-    return o;
-  }
 
   /** @ngInject */
   function configure(routerHelperProvider, exceptionHandlerProvider) {


### PR DESCRIPTION
This makes the product name static, untranslated, both on the login screen, and in the [alt] for the brand image..

Cc @mzazrivec 
@dclarizio , @chessbyte I'm guessing we may want this in today, as per John's mail..

https://bugzilla.redhat.com/show_bug.cgi?id=1356254
https://bugzilla.redhat.com/show_bug.cgi?id=1356256