### PR TITLE
SSUI Designer: Updated Blueprint List View Filters and Publish Blueprint validations

### DIFF
--- a/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
+++ b/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
@@ -348,7 +348,7 @@
       }
 
       var lastrow = actionOrderList[ actionOrderList.length - 1 ];
-      if (vm.actionOrderEqualsProvOrder && lastrow.columns[0].length === 0 && lastrow.columns[1].length === 0) {
+      if (lastrow && vm.actionOrderEqualsProvOrder && lastrow.columns[0].length === 0 && lastrow.columns[1].length === 0) {
         // remove last empty row
         actionOrderList.splice(actionOrderList.length - 1, 1);
       }

--- a/client/app/components/blueprint-details-modal/blueprint-details-modal.html
+++ b/client/app/components/blueprint-details-modal/blueprint-details-modal.html
@@ -14,7 +14,7 @@
             </tab-heading>
 
           <span ng-show="vm.isSelectedTab('general')">
-              <form novalidate name="detailsForm" id="detailsForm" class="form-horizontal">
+              <form name="detailsForm" id="detailsForm" class="form-horizontal">
                   <div pf-form-group pf-label-class="col-sm-4" pf-input-class="col-sm-6"
                        pf-label="{{'Blueprint Name'|translate}}"
                        required>
@@ -34,13 +34,13 @@
                       <label for="catalog" class="control-label col-sm-4" translate>Catalog</label>
 
                       <div class="col-sm-6">
-                          <select name="catalog" id="catalog" class="base-info-select"
+                          <select name="catalog" id="catalog" class="base-info-select form-control"
                                   ng-options="item as item.name for item in vm.serviceCatalogs"
                                   ng-model="vm.modalData.resource.catalog"
                                   ng-required="vm.isCatalogRequired()">
                               <option value="" translate>Unassigned</option>
-                          </select><br>
-                          <span ng-show="detailsForm.catalog.$error.required" class="control-label"
+                          </select>
+                          <span ng-show="detailsForm.catalog.$error.required" class="help-block"
                                 translate>Select a Catalog</span>
                           <button type="button" id="createCatalog" class="btn btn-default base-info-btn"
                                   ng-click="vm.createCatalog()"
@@ -52,13 +52,13 @@
                       <label for="dialog" class="control-label col-sm-4" translate>Dialog</label>
 
                       <div class="col-sm-6">
-                          <select name="dialog" id="dialog" class="base-info-select"
+                          <select name="dialog" id="dialog" class="base-info-select form-control"
                                   ng-options="item as item.description for item in vm.serviceDialogs"
                                   ng-model="vm.modalData.resource.dialog"
                                   ng-required="vm.isDialogRequired()">
                               <option value="" translate>Select Dialog</option>
-                          </select><br>
-                          <span ng-show="detailsForm.dialog.$error.required" class="control-label"
+                          </select>
+                          <span ng-show="detailsForm.dialog.$error.required" class="help-block"
                                 translate>Select a Dialog</span>
                       </div>
                   </div>
@@ -74,14 +74,14 @@
                           <label for="provEP" class="control-label col-sm-4" translate>Provisioning Entry Point</label>
 
                           <div class="col-sm-8">
-                              <input name="provEP" id="provEP" class="entry-point-input" name="provEP" type="text"
+                              <input name="provEP" id="provEP" class="entry-point-input form-control" name="provEP" type="text"
                                      ng-model="vm.modalData.resource.provEP" required/>
                               <button type="button" class="btn btn-default entry-point-btn"
                                       ng-click="vm.selectEntryPoint('provisioning')" translate>Browse
                               </button>
                               <a ng-click="vm.modalData.resource.provEP = ''"><span
                                       class="pficon pficon-close clear-entry-point"></span></a>
-                              <span ng-show="advOptsForm.provEP.$error.required" class="control-label" translate>Please enter a Provisioning Entry Point</span>
+                              <span ng-show="advOptsForm.provEP.$error.required" class="help-block" translate>Please enter a Provisioning Entry Point</span>
                           </div>
                       </div>
                       <div pf-form-group pf-label-class="col-sm-4" pf-input-class="col-sm-8"
@@ -161,7 +161,7 @@
     <button type="button"
             class="btn btn-primary"
             ng-click="vm.saveBlueprintDetails()"
-            ng-disabled="detailsForm.catalog.$error.required || detailsForm.dialog.$error.required || detailsForm.name.$error.required || advOptsForm.provEP.$error.required">
+            ng-disabled="!vm.modalData.resource.name || !vm.modalData.resource.catalog || !vm.modalData.resource.dialog || !vm.modalData.resource.provEP">
         {{vm.modalBtnPrimaryLabel}}
     </button>
 </div>

--- a/client/app/components/blueprint-details-modal/order-list.directive.js
+++ b/client/app/components/blueprint-details-modal/order-list.directive.js
@@ -79,7 +79,7 @@
 
       // if last row not empty, add new empty row (list number)
       container = containers[containers.length - 1];
-      if (container.type === 'container' && !$scope.listDisabled &&
+      if (container && container.type === 'container' && !$scope.listDisabled &&
          (container.columns[0].length !== 0 || container.columns[1].length !== 0)) {
         addEmptyContainerRow(containers);
       }

--- a/client/app/states/blueprints/list/list.state.js
+++ b/client/app/states/blueprints/list/list.state.js
@@ -51,6 +51,7 @@
     var vm = this;
     var categoryNames = [];
     var visibilityNames = ['Private', 'Public'];
+    var publishStateNames = ['Draft', 'Published'];
 
     vm.title = __('Blueprint List');
 
@@ -157,6 +158,13 @@
             placeholder: __('Filter by Catalog'),
             filterType: 'select',
             filterValues: categoryNames
+          },
+          {
+            id: 'publishState',
+            title: __('Publish State'),
+            placeholder: __('Filter by Publish State'),
+            filterType: 'select',
+            filterValues: publishStateNames
           }
         ],
         resultsCount: vm.blueprintsList.length,
@@ -355,6 +363,13 @@
           return false;
         } else {
           return item.catalog.name.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
+        }
+      } else if (filter.id === 'publishState') {
+        if ( (filter.value.toLowerCase() === "published" && item.published) ||
+             (filter.value.toLowerCase() === "draft" && !item.published)) {
+          return true;
+        } else {
+          return false;
         }
       }
 

--- a/client/app/states/blueprints/list/list.state.js
+++ b/client/app/states/blueprints/list/list.state.js
@@ -50,6 +50,7 @@
     /* jshint validthis: true */
     var vm = this;
     var categoryNames = [];
+    var visibilityNames = ['Private', 'Public'];
 
     vm.title = __('Blueprint List');
 
@@ -59,18 +60,22 @@
     }
 
     vm.blueprints = BlueprintsState.getBlueprints();
-    angular.forEach(vm.blueprints, addMockCategoryFilter);
-
     vm.serviceCatalogs = serviceCatalogs.resources;
+
+    angular.forEach(vm.blueprints, addMockFilters);
     angular.forEach(vm.serviceCatalogs, addCategoryFilter);
 
-    function addMockCategoryFilter(blueprint) {
+    function addMockFilters(blueprint) {
       if (!blueprint.catalog) {
         if (!categoryNames.includes(__('Unassigned'))) {
           categoryNames.push(__('Unassigned'));
         }
       } else {
         categoryNames.push(blueprint.catalog.name);
+      }
+
+      if (!visibilityNames.includes(blueprint.visibility.name)) {
+        visibilityNames.push(blueprint.visibility.name);
       }
     }
 
@@ -143,7 +148,8 @@
             id: 'visibility',
             title: __('Visibility'),
             placeholder: __('Filter by Visibility'),
-            filterType: 'text'
+            filterType: 'select',
+            filterValues: visibilityNames
           },
           {
             id: 'catalog',


### PR DESCRIPTION
In this PR I updated the Category and Visibility filters from free-form text entry to selecting values from a list.  
![image](https://cloud.githubusercontent.com/assets/12733153/17300652/4fe1337a-57e1-11e6-8123-8885a4bb02ba.png)

I also created a new Publish State filter:
![image](https://cloud.githubusercontent.com/assets/12733153/17300548/e03a21bc-57e0-11e6-8bbb-b69707e8c5a3.png)

I also fixed validation when Publishing a blueprint.  Validation errors now appear as red errors:

![image](https://cloud.githubusercontent.com/assets/12733153/17300582/fe58de4a-57e0-11e6-8def-4f3f3c503bd9.png)

Plus fixed a minor NPE bug when attempting to launch Blueprint Details modal dialog when there are no service items on canvas.