### PR TITLE
[DARGA] Fix missing languages in login screen language switcher

### DIFF
--- a/client/app/components/language-switcher/language-switcher.directive.js
+++ b/client/app/components/language-switcher/language-switcher.directive.js
@@ -20,7 +20,7 @@
     return directive;
 
     /** @ngInject */
-    function LanguageSwitcherController($scope, gettextCatalog, Language, lodash, $state) {
+    function LanguageSwitcherController($scope, gettextCatalog, Language, lodash, $state, $timeout, jQuery) {
       var vm = this;
       vm.mode = vm.mode || 'menu';
 
@@ -47,6 +47,14 @@
       Language.ready
         .then(function(available) {
           vm.available = lodash.extend({}, hardcoded, available);
+
+          // angular-patternfly 2.* compatibility hack: trigger pf-select refresh manually
+          // need to do this in $timeout, to give angular time to populate the <select> first
+          if (vm.mode !== 'menu') {
+            $timeout(function() {
+              jQuery('[pf-select]').selectpicker('refresh');
+            });
+          }
         });
 
       vm.switch = function(code) {


### PR DESCRIPTION
The list of available languages is pulled asynchronously, and when it's downloaded only after the language switcher select has been populated, angular updates the <select> element, but angular-patternfly 2.* won't update the visible selectpicker after.

Thus, sometimes, there are no languages in the selector.

This manually triggers a refresh of that selectpicker after the list is downloaded and the <select> is populated.

(This is not needed in master because angular-patternfly 3.* already does the right thing - #73)

https://bugzilla.redhat.com/show_bug.cgi?id=1363753