### PR TITLE
My Requests styling fix

### DIFF
--- a/client/app/states/requests/details/details.html
+++ b/client/app/states/requests/details/details.html
@@ -81,7 +81,7 @@
                 <div class="form-group">
                   <label class="control-label col-sm-4" translate>Last Message</label>
                   <div class="col-sm-8">
-                    <p class="form-control" disabled>
+                    <p class="form-control-static" disabled>
                       {{ ::vm.request.message}}
                     </p>
                   </div>


### PR DESCRIPTION
The "Last Message" field was overlapping other form elements when there was a long message. Replacing "form-control" with "form-control-static" class allows it to wrap properly.

https://bugzilla.redhat.com/show_bug.cgi?id=1365023

Old
<img width="1357" alt="screen shot 2016-08-10 at 1 05 45 pm" src="https://cloud.githubusercontent.com/assets/1287144/17562982/46eac5d0-5efb-11e6-9a8c-2a7da713203c.png">

New
<img width="1355" alt="screen shot 2016-08-10 at 1 03 17 pm" src="https://cloud.githubusercontent.com/assets/1287144/17562981/46e8cbe0-5efb-11e6-8af0-617e3f804b29.png">