### PR TITLE
Add tooltips for Service List items

### DIFF
--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -16,30 +16,45 @@
             <img class="ss-list-view__title-img__logo" ng-src="{{ ::item.picture.image_href }}" ng-if=" ::item.picture.image_href"/>
             <img class="ss-list-view__title-img__logo" src="images/service.png" ng-if=" ::!item.picture.image_href"/>
           </span>
-          {{ item.name }}
+          <span tooltip="{{ item.name }}" tooltip-placement="bottom">
+            {{ item.name }}
+          </span>
         </span>
       </div>
       <div class="col-lg-3 col-md-4 col-sm-6 col-xs-6">
         <span class="no-wrap">
           <strong translate>Retirement Date</strong>&nbsp;
-          <span ng-if=(item.retires_on)>{{ item.retires_on | date }}</span>
-          <span ng-if=!(item.retires_on) translate>Never</span>
+          <span ng-if=(item.retires_on) tooltip="{{ item.retires_on | date }}" tooltip-placement="bottom">
+            {{ item.retires_on | date }}
+          </span>
+          <span ng-if=!(item.retires_on) translate tooltip="{{'Never'|translate}}" tooltip-placement="bottom">
+            Never
+          </span>
         </span>
       </div>
        <div class="col-lg-2 col-md-2 hidden-sm hidden-xs">
         <span class="no-wrap">
            <i class="pficon pficon-screen" tooltip="{{'The number of instances running this service'|translate}}" tooltip-placement="bottom"></i>
-          <span><strong>{{ item.v_total_vms}}</strong> {{'VMs'|translate}}</span>
+          <span translate tooltip="{{item.v_total_vms}} VMs" tooltip-placement="bottom">
+            <strong>{{ item.v_total_vms}}</strong>
+            {{'VMs'|translate}}
+          </span>
         </span>
       </div>
       <div class="col-lg-2 col-md-2 hidden-sm hidden-xs">
         <span class="no-wrap">
-          <i class="pficon pficon-user" tooltip="{{'Owner'|translate}}" tooltip-placement="bottom"></i>{{ item.evm_owner.name }}
+          <i class="pficon pficon-user" tooltip="{{'Owner'|translate}}" tooltip-placement="bottom"></i>
+          <span tooltip="{{ item.evm_owner.name }}" tooltip-placement="bottom">
+            {{ item.evm_owner.name }}
+          </span>
         </span>
       </div>
       <div class="col-lg-2 hidden-md hidden-sm hidden-xs">
         <span class="no-wrap">
-          <strong translate>Created On</strong>&nbsp;{{ item.created_at | date }}
+          <strong translate>Created On</strong>&nbsp;
+          <span tooltip="{{ item.created_at | date }}" tooltip-placement="bottom">
+            {{ item.created_at | date }}
+          </span>
         </span>
       </div>
     </div>


### PR DESCRIPTION
Going forward we anticipate having more columns(for buttons/menus) in the Service List which would mean we would have to fit more in the existing `col-md-12` grid layout. 
This may lead to the column data getting truncated if the length of the data exceeds the column length.

A truncation example is shown below -
<img width="812" alt="screen shot 2016-08-26 at 4 25 50 pm" src="https://cloud.githubusercontent.com/assets/1538216/18023106/d9eaccee-6ba9-11e6-9cbd-4fdc6434f78a.png">

Hence tooltips to the rescue!

<img width="1336" alt="screen shot 2016-08-26 at 4 27 51 pm" src="https://cloud.githubusercontent.com/assets/1538216/18023137/2912e77a-6baa-11e6-8d83-7f46696db1bf.png">




