### PR TITLE
dev server - serve .tmp, not tmp

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -66,7 +66,7 @@ switch (environment) {
   default:
     console.log('** DEV **');
     router.use(express.static('./client/'));
-    router.use(express.static('./tmp'));
+    router.use(express.static('./.tmp')); // gulp dev build dir
     router.use(express.static('./client/assets'));
     var pictureProxy = httpProxy.createProxyServer({
       target: 'http://' + PROXY_HOST + '/pictures',


### PR DESCRIPTION
This fixes the issue that skinned images were not provided in /images when running the devel server.

For the server, `/images` would mean `client/images`, now, `.tmp/images` (where the dev build process puts them) takes precedence.

Cc: @epwinchell, @Fryguy 

https://bugzilla.redhat.com/show_bug.cgi?id=1366357