### PR TITLE
Product logo not displayed on login screen

### DIFF
--- a/client/app/states/login/login.html
+++ b/client/app/states/login/login.html
@@ -1,4 +1,7 @@
 <div class="login-pf">
+  <span id="badge">
+    <img src="images/login-screen-logo.png" alt=" logo" />
+  </span>
   <div class="container">
     <div class="row">
       <div class="col-sm-12">


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq-ui-self_service/pull/116
https://bugzilla.redhat.com/show_bug.cgi?id=1366357

Old
<img width="1134" alt="screen shot 2016-09-06 at 3 50 57 pm" src="https://cloud.githubusercontent.com/assets/1287144/18288597/23b23346-744a-11e6-9e48-e5459a7bba6d.png">

New
<img width="1136" alt="screen shot 2016-09-06 at 3 49 45 pm" src="https://cloud.githubusercontent.com/assets/1287144/18288598/23c42d94-744a-11e6-8720-f62156f7c0d8.png">