### PR TITLE
Force eonasdan-bootstrap-datetimepicker to a version that does not pollute module.exports

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,8 @@
     "patternfly": "^3.10.0",
     "spice-html5-bower": "v0.1.6.1",
     "sprintf": "~1.0.3",
-    "toastr": "~2.1.1"
+    "toastr": "~2.1.1",
+    "eonasdan-bootstrap-datetimepicker": "=4.17.37"
   },
   "overrides": {
     "no-vnc": {


### PR DESCRIPTION
`eonasdan-bootstrap-datetimepicker` 4.17.42 when run with `angular-mocks` decides that `module` means it can `module.export`, which in turn makes `toastr` expect to be able to use `require`..

Forcing explicitly 4.17.37 (the minimum requirement for patternfly), which doesn't have this problem.

Related: https://github.com/Eonasdan/bootstrap-datetimepicker/pull/1771

This thus fixes the javascript test failure..
```
  ReferenceError: Can't find variable: require
  at /home/travis/build/ManageIQ/manageiq-ui-self_service/bower_components/toastr/toastr.js:472

  ReferenceError: Can't find variable: toastr
  at /home/travis/build/ManageIQ/manageiq-ui-self_service/client/app/core/constants.js:9
```
