### PR TITLE
Ensure the default_value for a drop down is not a blank one

### DIFF
--- a/client/app/components/dialog-content/dialog-content.html
+++ b/client/app/components/dialog-content/dialog-content.html
@@ -63,11 +63,8 @@
                       ng-model="dialogField.default_value"
                       ng-disabled="dialogField.read_only || vm.inputDisabled"
                       ng-change="dialogField.triggerAutoRefresh(dialogField)"
-                      class="form-control">
-                      <option ng-repeat="fieldValue in dialogField.values"
-                              value="{{ fieldValue[0] }}">
-                        {{ fieldValue[1] }}
-                      </option>
+                      class="form-control"
+                      ng-options="fieldValue[0] as fieldValue[1] for fieldValue in dialogField.values">
                     </select>
 
                     <span

--- a/client/app/services/dialog-field-refresh.service.js
+++ b/client/app/services/dialog-field-refresh.service.js
@@ -55,19 +55,33 @@
       fetchDialogFieldInfo(allDialogFields, [dialogField.name], url, resourceId, refreshSuccess, refreshFailure);
     }
 
+    function selectDefaultValue(dialogField, newDialogField) {
+      if (typeof (newDialogField.values) === 'object') {
+        dialogField.values = newDialogField.values;
+        if (newDialogField.default_value !== undefined && newDialogField.default_value !== null) {
+          dialogField.default_value = newDialogField.default_value;
+        } else {
+          dialogField.default_value = newDialogField.values[0][0];
+        }
+      } else {
+        if (dialogField.type === 'DialogFieldDateControl' || dialogField.type === 'DialogFieldDateTimeControl') {
+          dialogField.default_value = new Date(newDialogField.values);
+        } else {
+          if (newDialogField.default_value === undefined || newDialogField.default_value === null || newDialogField.default_value === '') {
+            dialogField.default_value = newDialogField.values;
+          }
+        }
+      }
+    }
+
     function setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields) {
       angular.forEach(dialogs, function(dialog) {
         angular.forEach(dialog.dialog_tabs, function(dialogTab) {
           angular.forEach(dialogTab.dialog_groups, function(dialogGroup) {
             angular.forEach(dialogGroup.dialog_fields, function(dialogField) {
               allDialogFields.push(dialogField);
-              if (dialogField.default_value === '' && dialogField.values !== '') {
-                dialogField.default_value = dialogField.values;
-              }
 
-              if (typeof (dialogField.values) === 'object' && dialogField.default_value === undefined) {
-                dialogField.default_value = String(dialogField.values[0][0]);
-              }
+              selectDefaultValue(dialogField, dialogField);
 
               dialogField.triggerAutoRefresh = function() {
                 triggerAutoRefresh(dialogField);
@@ -110,20 +124,7 @@
     function updateAttributesForDialogField(dialogField, newDialogField) {
       copyDynamicAttributes(dialogField, newDialogField);
 
-      if (typeof (newDialogField.values) === 'object') {
-        dialogField.values = newDialogField.values;
-        if (newDialogField.default_value !== undefined && newDialogField.default_value !== null) {
-          dialogField.default_value = newDialogField.default_value;
-        } else {
-          dialogField.default_value = String(newDialogField.values[0][0]);
-        }
-      } else {
-        if (dialogField.type === 'DialogFieldDateControl' || dialogField.type === 'DialogFieldDateTimeControl') {
-          dialogField.default_value = new Date(newDialogField.values);
-        } else {
-          dialogField.default_value = newDialogField.values;
-        }
-      }
+      selectDefaultValue(dialogField, newDialogField);
 
       dialogField.beingRefreshed = false;
 

--- a/tests/dialog-field-refresh.service.spec.js
+++ b/tests/dialog-field-refresh.service.spec.js
@@ -280,23 +280,45 @@ describe('app.services.DialogFieldRefresh', function() {
       });
     });
 
-    describe('when the dialog field has an object for values but no default value', function() {
-      var dialogField = {name: 'dialog1', values: [[1, 'one']]};
-      var dialogs = [{dialog_tabs: [{dialog_groups: [{dialog_fields: [dialogField]}]}]}];
+    describe('when the dialog field has an object for values', function() {
+      describe('when there is no default value assigned', function() {
+        var dialogField = {name: 'dialog1', values: [[1, 'one'], [2, 'two']], default_value: null};
+        var dialogs = [{dialog_tabs: [{dialog_groups: [{dialog_fields: [dialogField]}]}]}];
 
-      it('pushes the dialog field into the all dialog fields array', function() {
-        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
-        expect(allDialogFields.length).to.equal(1);
+        it('pushes the dialog field into the all dialog fields array', function() {
+          DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+          expect(allDialogFields.length).to.equal(1);
+        });
+
+        it('assigns the default value to the first value', function() {
+          DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+          expect(dialogField.default_value).to.equal(1);
+        });
+
+        it('sets up the triggering of auto refresh', function() {
+          DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+          expect(dialogField).to.respondTo('triggerAutoRefresh');
+        });
       });
 
-      it('assigns the default value', function() {
-        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
-        expect(dialogField.default_value).to.equal('1');
-      });
+      describe('when there is a default value assigned', function() {
+        var dialogField = {name: 'dialog1', values: [[1, 'one'], [2, 'two']], default_value: 2};
+        var dialogs = [{dialog_tabs: [{dialog_groups: [{dialog_fields: [dialogField]}]}]}];
 
-      it('sets up the triggering of auto refresh', function() {
-        DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
-        expect(dialogField).to.respondTo('triggerAutoRefresh');
+        it('pushes the dialog field into the all dialog fields array', function() {
+          DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+          expect(allDialogFields.length).to.equal(1);
+        });
+
+        it('assigns the default value', function() {
+          DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+          expect(dialogField.default_value).to.equal(2);
+        });
+
+        it('sets up the triggering of auto refresh', function() {
+          DialogFieldRefresh.setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields);
+          expect(dialogField).to.respondTo('triggerAutoRefresh');
+        });
       });
     });
 


### PR DESCRIPTION
This PR will make sure that the first item in a drop down list is selected by default if there is no default value given. Before, it would create a blank entry and if the user submitted this, it would come across as "null".  If the default value's key is "null", it will still select the first value instead of selecting nothing. This way we should always get something passed in, even if the first actual value's key is *supposed* to be "null". I'd argue that it's probably not a great idea to have a key with the name of "null", but since that can't be changed right now, this should help.

https://bugzilla.redhat.com/show_bug.cgi?id=1374398

@bzwei Hopefully this resolves the issue, can you test this and see?
@gmcculloug Not sure if you want to review but figure I'll tag you anyway.