### PR TITLE
Add Notifications Drawer and Toast Notifications List

### DIFF
--- a/client/app/components/_components.sass
+++ b/client/app/components/_components.sass
@@ -4,6 +4,7 @@
 
 @import 'dialog-content/dialog-content'
 @import 'navigation/navigation'
+@import 'notifications/notifications'
 @import 'ss-card/ss-card'
 @import 'toasts/toasts'
 @import 'confirmation/confirmation'

--- a/client/app/components/blueprint-delete-modal/blueprint-delete-modal-service.factory.js
+++ b/client/app/components/blueprint-delete-modal/blueprint-delete-modal-service.factory.js
@@ -32,7 +32,7 @@
   }
 
   /** @ngInject */
-  function BlueprintDeleteModalController(blueprints, BlueprintsState, $state, $modalInstance, CollectionsApi, Notifications) {
+  function BlueprintDeleteModalController(blueprints, BlueprintsState, $state, $modalInstance, CollectionsApi) {
     var vm = this;
 
     vm.blueprintsList = blueprints;

--- a/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
+++ b/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
@@ -74,7 +74,7 @@
   /** @ngInject */
   function BlueprintDetailsModalController(action, blueprint, BlueprintsState, BlueprintOrderListService, serviceCatalogs,  // jshint ignore:line
                                            serviceDialogs, tenants, $state, BrowseEntryPointModal, CreateCatalogModal, $modalInstance,
-                                           Notifications, sprintf, $scope) {
+                                           EventNotifications, sprintf, $scope) {
     var vm = this;
     vm.blueprint = blueprint;
 
@@ -318,25 +318,25 @@
         if (action === 'create') {
           // This is not actually used anymore, flow has changed
           // keeping it in case flow changes back again.
-          Notifications.success(sprintf(__('%s was created.'), vm.blueprint.name));
+          EventNotifications.success(sprintf(__('%s was created.'), vm.blueprint.name));
           $modalInstance.close();
           BlueprintsState.saveBlueprint(vm.blueprint);
           $state.go('designer/blueprints.editor', {blueprintId: vm.blueprint.id});
         } else if (action === 'edit') {
           $modalInstance.close({editedblueprint: vm.blueprint});
-          // Notifications.success(sprintf(__('%s details were updated.'), vm.blueprint.name));
+          // EventNotifications.success(sprintf(__('%s details were updated.'), vm.blueprint.name));
         } else if (action === 'publish') {
           $modalInstance.close();
-          Notifications.success(sprintf(__('%s was published.'), vm.blueprint.name));
+          EventNotifications.success(sprintf(__('%s was published.'), vm.blueprint.name));
           $state.go($state.current, {}, {reload: true});
         }
       }
 
       function saveFailure() {
         if (action === 'publish') {
-          Notifications.error(__('The Publish Blueprint feature is not yet implemented.'));
+          EventNotifications.error(__('The Publish Blueprint feature is not yet implemented.'));
         } else {
-          Notifications.error(__("There was an error saving this Blueprint's Details."));
+          EventNotifications.error(__("There was an error saving this Blueprint's Details."));
         }
       }
 

--- a/client/app/components/blueprint-details-modal/blueprint-order-list.service.js
+++ b/client/app/components/blueprint-details-modal/blueprint-order-list.service.js
@@ -5,7 +5,7 @@
       .factory('BlueprintOrderListService', BlueprintOrderListFactory);
 
   /** @ngInject */
-  function BlueprintOrderListFactory(CollectionsApi, Notifications, sprintf, $q) {
+  function BlueprintOrderListFactory(CollectionsApi, sprintf, $q) {
     var orderListSrv = {};
 
     /*

--- a/client/app/components/custom-button/custom-button.directive.js
+++ b/client/app/components/custom-button/custom-button.directive.js
@@ -61,7 +61,7 @@
     }
 
     /** @ngInject */
-    function CustomButtonController($state, Notifications, CollectionsApi) {
+    function CustomButtonController($state, EventNotifications, CollectionsApi) {
       var vm = this;
 
       vm.activate = activate;
@@ -97,7 +97,7 @@
           } else if (assignedButton.method === 'delete') {
             CollectionsApi.delete(assignedButton.collection, assignedButton.id, {}).then(deleteSuccess, deleteFailure);
           } else {
-            Notifications.error(__('Button action not supported.'));
+            EventNotifications.error(__('Button action not supported.'));
           }
         }
 
@@ -110,26 +110,26 @@
 
         function postSuccess(response) {
           if (response.success === false) {
-            Notifications.error(response.message);
+            EventNotifications.error(response.message);
           } else {
-            Notifications.success(response.message);
+            EventNotifications.success(response.message);
           }
         }
 
         function postFailure() {
-          Notifications.error(__('Action not able to submit.'));
+          EventNotifications.error(__('Action not able to submit.'));
         }
 
         function deleteSuccess(response) {
           if (response.success === false) {
-            Notifications.error(response.message);
+            EventNotifications.error(response.message);
           } else {
-            Notifications.success(response.message);
+            EventNotifications.success(response.message);
           }
         }
 
         function deleteFailure() {
-          Notifications.error(__('Action not able to submit.'));
+          EventNotifications.error(__('Action not able to submit.'));
         }
       }
     }

--- a/client/app/components/edit-service-modal/edit-service-modal-service.factory.js
+++ b/client/app/components/edit-service-modal/edit-service-modal-service.factory.js
@@ -33,7 +33,7 @@
   }
 
   /** @ngInject */
-  function EditServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, Notifications) {
+  function EditServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, EventNotifications) {
     var vm = this;
 
     vm.service = serviceDetails;
@@ -57,12 +57,12 @@
 
       function saveSuccess() {
         $modalInstance.close();
-        Notifications.success(vm.service.name + __(' was edited.'));
+        EventNotifications.success(vm.service.name + __(' was edited.'));
         $state.go($state.current, {}, {reload: true});
       }
 
       function saveFailure() {
-        Notifications.error(__('There was an error editing this service.'));
+        EventNotifications.error(__('There was an error editing this service.'));
       }
     }
   }

--- a/client/app/components/notifications/_notifications.sass
+++ b/client/app/components/notifications/_notifications.sass
@@ -1,0 +1,43 @@
+.drawer-pf
+  right: 15px
+
+  .panel-counter.sub-heading
+    font-size: 12px
+    font-weight: normal
+
+.drawer-pf-notification
+  .progress
+    background-color: #fff
+    border-color: #292e34
+    border-radius: 5px
+    box-shadow: inset 0 0 1px rgba(3,3,3,1)
+    height: 10px
+    margin-bottom: 0px
+    .progress-bar-info
+      background-color: #0088ce
+  .mini-progress
+    .time
+      left: 40px
+      position: absolute
+      width: 65px
+    .mini-progress-area
+      left: 115px
+      margin-bottom: 5px
+      margin-top: 5px
+      position: absolute
+      right: 55px
+
+.drawer-pf-action.footer-actions
+  width: 100%
+
+  .footer-button-left
+    display: inline-block
+    width: calc(50% - 25px)
+    text-align: right
+    margin: 0 10px
+
+  .footer-button-right
+    display: inline-block
+    width: calc(50% - 35px)
+    text-align: left
+    margin: 0 10px

--- a/client/app/components/notifications/heading.html
+++ b/client/app/components/notifications/heading.html
@@ -1,0 +1,3 @@
+<span class="heading-class">{{notificationGroup.heading | translate}}</span>
+<span class="panel-counter sub-heading">{{notificationGroup.unreadCount}} {{'New' | translate}} {{notificationGroup.heading | translate}}</span>
+

--- a/client/app/components/notifications/notification-body.html
+++ b/client/app/components/notifications/notification-body.html
@@ -37,7 +37,7 @@
     </div>
     <div class="col-md-4 col-sm-3" ng-if="notificationGroup.notificationType == 'task'">
       <div class="drawer-pf-notification-info expanded-info" ng-click="customScope.markRead(notification, notificationGroup)">
-        <span class="info-title">Started: </span>
+        <span class="info-title" translate>Started: </span>
         <span class="date">{{notification.data.startTime | date:'MM/dd/yyyy'}}</span>
         <span class="time">{{notification.data.startTime | date:'h:mm:ss a'}}</span>
       </div>
@@ -49,7 +49,7 @@
     </div>
     <div class="col-md-4 col-sm-3" ng-if="notificationGroup.notificationType == 'task'">
       <div class="drawer-pf-notification-info" ng-click="customScope.markRead(notification, notificationGroup)">
-        <span class="info-title">Completed: </span>
+        <span class="info-title" translate>Completed: </span>
         <span class="date">{{notification.data.endTime | date:'MM/dd/yyyy'}}</span>
         <span class="time">{{notification.data.endTime | date:'h:mm:ss a'}}</span>
       </div>

--- a/client/app/components/notifications/notification-body.html
+++ b/client/app/components/notifications/notification-body.html
@@ -1,0 +1,69 @@
+<div ng-if="!drawerExpanded" ng-click="customScope.markNotificationRead(notification, notificationGroup)">
+  <div class="dropdown pull-right dropdown-kebab-pf">
+    <button class="btn btn-link dropdown-toggle" type="button" ng-click="customScope.clearNotification(notification, notificationGroup)">
+      <span class="pficon pficon-close"></span>
+    </button>
+  </div>
+  <span ng-if="notification.type" class="pull-left {{customScope.getNotficationStatusIconClass(notification)}}" ng-click="customScope.markRead(notification, notificationGroup)"></span>
+  <span class="drawer-pf-notification-message notification-message"
+        ng-click="customScope.markRead(notification, notificationGroup)"
+        tooltip-popup-delay="500" tooltip-placement="bottom" tooltip="{{notification.message | translate}}">
+    {{notification.message | translate}}
+  </span>
+  <div ng-if="!notification.data.inProgress" class="drawer-pf-notification-info" ng-click="customScope.markRead(notification, notificationGroup)">
+    <span class="date">{{notification.timeStamp | date:'MM/dd/yyyy'}}</span>
+    <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>
+  </div>
+  <div ng-if="notification.data.inProgress" class="mini-progress clearfix">
+    <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>
+    <div class="mini-progress-area">
+      <div class="progress">
+        <span class="progress-bar progress-bar-info"
+              ng-style="{width: notification.data.percentComplete + '%'}" tooltip="{{notification.data.percentComplete}} + {{'% Complete' | translate}}">
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+<div ng-if="drawerExpanded" class="container-fluid expanded-notification" ng-click="customScope.markNotificationRead(notification, notificationGroup)">
+  <div class="row">
+    <div ng-class="{'col-md-4': notificationGroup.notificationType == 'task'}" class="col-sm-6">
+      <span ng-if="notification.type" class="pull-left {{customScope.getNotficationStatusIconClass(notification)}}" ng-click="customScope.markRead(notification, notificationGroup)"></span>
+      <span class="drawer-pf-notification-message notification-message"
+            ng-click="customScope.markRead(notification, notificationGroup)"
+            tooltip-append-to-body="true" tooltip-popup-delay="500" tooltip-placement="bottom" tooltip="{{notification.message | translate}}">
+            {{notification.message | translate}}
+      </span>
+    </div>
+    <div class="col-md-4 col-sm-3" ng-if="notificationGroup.notificationType == 'task'">
+      <div class="drawer-pf-notification-info expanded-info" ng-click="customScope.markRead(notification, notificationGroup)">
+        <span class="info-title">Started: </span>
+        <span class="date">{{notification.data.startTime | date:'MM/dd/yyyy'}}</span>
+        <span class="time">{{notification.data.startTime | date:'h:mm:ss a'}}</span>
+      </div>
+      <div ng-if="notification.inProgress" class="progress">
+        <div class="progress-bar progress-bar-info"
+             ng-style="{width: notification.data.percentComplete + '%'}" tooltip="{{notification.data.percentComplete}} + {{'% Complete' | translate}}">
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4 col-sm-3" ng-if="notificationGroup.notificationType == 'task'">
+      <div class="drawer-pf-notification-info" ng-click="customScope.markRead(notification, notificationGroup)">
+        <span class="info-title">Completed: </span>
+        <span class="date">{{notification.data.endTime | date:'MM/dd/yyyy'}}</span>
+        <span class="time">{{notification.data.endTime | date:'h:mm:ss a'}}</span>
+      </div>
+    </div>
+    <div class="col-sm-6" ng-if="notificationGroup.notificationType == 'event'">
+      <div class="drawer-pf-notification-info" ng-click="customScope.markRead(notification, notificationGroup)">
+        <span class="date">{{notification.timeStamp | date:'MM/dd/yyyy'}}</span>
+        <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>
+      </div>
+    </div>
+    <div class="pull-right dropdown-kebab-pf">
+      <button class="btn btn-link dropdown-toggle" type="button" ng-click="customScope.clearNotification(notification, notificationGroup)">
+        <span class="pficon pficon-close"></span>
+      </button>
+    </div>
+  </div>
+</div>

--- a/client/app/components/notifications/notification-footer.html
+++ b/client/app/components/notifications/notification-footer.html
@@ -1,0 +1,24 @@
+<div class="drawer-pf-action footer-actions">
+  <div class="footer-button-left">
+    <a class="btn btn-link" role="button"
+       ng-class="{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}"
+       ng-click="customScope.markAllRead(notificationGroup)">
+      <span>{{'Mark All Read' | translate}}</span>
+    </a>
+  </div>
+  <div class="footer-button-right">
+    <a class="btn btn-link" role="button"
+       ng-class="{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}"
+       confirmation
+       confirmation-if="true"
+       confirmation-title="{{'Clear All ' + notificationGroup.heading |translate}}"
+       confirmation-message="{{'Are you sure you would like to clear all ' + notificationGroup.heading + '?'|translate}}"
+       confirmation-ok-text="{{'Clear All'|translate}}"
+       confirmation-on-ok="customScope.clearAllNotifications(notificationGroup)"
+       confirmation-ok-style="primary"
+       confirmation-show-cancel="true" >
+      <span class="pficon pficon-close"></span>
+      <span>{{'Clear All' | translate}}</span>
+    </a>
+  </div>
+</div>

--- a/client/app/components/notifications/subheading.html
+++ b/client/app/components/notifications/subheading.html
@@ -1,0 +1,1 @@
+<span class="subheading-class">{{notificationGroup.unreadCount}} {{'New' | translate}}</span>

--- a/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
+++ b/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
@@ -56,7 +56,7 @@
   }
 
   /** @ngInject */
-  function OwnershipServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, Notifications, users, groups, sprintf) {
+  function OwnershipServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, EventNotifications, users, groups, sprintf) {
     var vm = this;
 
     vm.service = serviceDetails;
@@ -85,12 +85,12 @@
 
       function saveSuccess() {
         $modalInstance.close();
-        Notifications.success(__(sprintf("%s ownership was saved.", vm.service.name)));
+        EventNotifications.success(__(sprintf("%s ownership was saved.", vm.service.name)));
         $state.go($state.current, {}, {reload: true});
       }
 
       function saveFailure() {
-        Notifications.error(__('There was an error saving ownership of this service.'));
+        EventNotifications.error(__('There was an error saving ownership of this service.'));
       }
     }
   }

--- a/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
+++ b/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
@@ -33,7 +33,7 @@
   }
 
   /** @ngInject */
-  function RetireServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, Notifications) {
+  function RetireServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, EventNotifications) {
     var vm = this;
 
     vm.service = serviceDetails;
@@ -72,12 +72,12 @@
 
       function retireSuccess() {
         $modalInstance.close();
-        Notifications.success(__('Scheduling retirement for') + vm.service.name  + '.');
+        EventNotifications.success(__('Scheduling retirement for') + vm.service.name  + '.');
         $state.go($state.current, {}, {reload: true});
       }
 
       function retireFailure() {
-        Notifications.error(__('There was an error retiring this service.'));
+        EventNotifications.error(__('There was an error retiring this service.'));
       }
     }
   }

--- a/client/app/components/shopping-cart/shopping-cart.directive.js
+++ b/client/app/components/shopping-cart/shopping-cart.directive.js
@@ -5,7 +5,7 @@
     .directive('shoppingCart', ShoppingCartDirective);
 
   /** @ngInject */
-  function ShoppingCartDirective(Notifications) {
+  function ShoppingCartDirective(EventNotifications) {
     var directive = {
       restrict: 'E',
       scope: {
@@ -44,11 +44,11 @@
       function submit() {
         ShoppingCart.submit()
         .then(function() {
-          Notifications.success(__('Shopping cart successfully ordered'));
+          EventNotifications.success(__('Shopping cart successfully ordered'));
           vm.modalInstance.dismiss();
         })
         .then(null, function(err) {
-          Notifications.error(__('There was an error submitting this request: ') + err);
+          EventNotifications.error(__('There was an error submitting this request: ') + err);
         });
       }
 

--- a/client/app/layouts/_application.sass
+++ b/client/app/layouts/_application.sass
@@ -15,30 +15,6 @@ body
   padding-left: 15px
   margin-bottom: 0
 
-.alert
-  margin: 20px
-  padding: 10px 10px 10px 37px
-  border-width: 1px
-
-  & > .pficon
-    top: 10px
-
-.alert-success
-  background: $app-color-light-green
-  border-color: $app-color-medium-green
-
-.alert-danger
-  background: $app-color-light-pink-2
-  border-color: $app-color-red
-
-.alert-warn
-  background: $app-color-light-orange
-  border-color: $app-color-orange-2
-
-.alert-info
-  background: $app-color-gray-2
-  border-color: $color-mountain-mist-approx
-
 .toolbar-pf .sort-pf .form-group
   border-right: 0
 

--- a/client/app/layouts/application.html
+++ b/client/app/layouts/application.html
@@ -1,6 +1,13 @@
 <div class="layout-application" ng-controller="navigationController as vm">
   <div pf-vertical-navigation items="vm.items" brand-src="images/brand.svg" brand-alt="{{ ::vm.text.name }}" update-active-items-on-click="true"
        pinnable-menus="true" item-click-callback="vm.handleItemClick" show-badges="true">
+    <div pf-toast-notification-list notifications="vm.toastNotifications" show-close="true" close-callback="vm.handleDismissToast" update-viewing="vm.updateViewingToast"></div>
+
+    <div pf-notification-drawer drawer-hidden="!vm.notificationsDrawerShown" notification-groups="vm.notificationGroups" allow-expand="true"
+         drawer-title="{{'Notifications' | translate}}" heading-include="{{vm.headingHTML}}" subheading-include="{{vm.subHeadingHTML}}"
+         notification-body-include="{{vm.notificationHTML}}" notification-footer-include="{{vm.notificationFooterHTML}}"
+         custom-scope="vm">
+    </div>
     <div>
       <ul class="nav navbar-nav">
         <li>
@@ -14,6 +21,11 @@
           <a title="{{'Shopping cart' | translate}}" class="nav-item-iconic" ng-click="vm.shoppingCart.open()">
             <i class="fa fa-shopping-cart"></i>
             <span class="badge" ng-show="vm.shoppingCart.count" ng-bind="vm.shoppingCart.count"></span>
+          </a>
+        </li>
+        <li>
+          <a title="{{'Toggle notifications list' | translate}}" class="nav-item-iconic" ng-click="vm.toggleNotificationsList()">
+            <span class="fa" ng-class="{'fa-bell': vm.newNotifications, 'fa-bell-o': !vm.newNotifications}"></span>
           </a>
         </li>
         <li dropdown>

--- a/client/app/services/blueprints-state.service.js
+++ b/client/app/services/blueprints-state.service.js
@@ -5,7 +5,7 @@
       .factory('BlueprintsState', BlueprintsStateFactory);
 
   /** @ngInject */
-  function BlueprintsStateFactory($filter, CollectionsApi, Notifications, $state, sprintf, $q) {
+  function BlueprintsStateFactory($filter, CollectionsApi, EventNotifications, $state, sprintf, $q) {
     var blueprint = {};
 
     blueprint.sort = {
@@ -162,7 +162,7 @@
               if (nodeSrvTemplate.id) {
                 serviceTemplates.push({"id": nodeSrvTemplate.id});
               } else {
-                Notifications.warn("Cannot Save New Generic Item '" + nodeSrvTemplate.name +
+                EventNotifications.warn("Cannot Save New Generic Item '" + nodeSrvTemplate.name +
                     "'.  Saving New Generic Items Not Yet Implemented.");
               }
             }
@@ -401,12 +401,12 @@
       CollectionsApi.post('blueprints', null, {}, blueprintObj).then(deleteSuccess, deleteFailure);
 
       function deleteSuccess() {
-        Notifications.success(__('Blueprint(s) were succesfully deleted.'));
+        EventNotifications.success(__('Blueprint(s) were succesfully deleted.'));
         deferred.resolve();
       }
 
       function deleteFailure() {
-        Notifications.error(__('There was an error deleting the blueprint(s).'));
+        EventNotifications.error(__('There was an error deleting the blueprint(s).'));
         deferred.reject();
       }
 

--- a/client/app/services/consoles.service.js
+++ b/client/app/services/consoles.service.js
@@ -5,7 +5,7 @@
     .factory('Consoles', ConsolesFactory);
 
   /** @ngInject */
-  function ConsolesFactory(CollectionsApi, $http, $timeout, logger, $location, Notifications) {
+  function ConsolesFactory(CollectionsApi, $http, $timeout, logger, $location, EventNotifications) {
     var service = {
       open: openConsole,
     };
@@ -27,14 +27,14 @@
         throw response.message;
       }
 
-      Notifications.info(__("Waiting for the console to become ready"));
+      EventNotifications.info(__("Waiting for the console to become ready"));
       logger.info(__("Waiting for the console to become ready:"), response.message);
 
       consoleWatch(response.task_href + '?attributes=task_results');
     }
 
     function consoleError(error) {
-      Notifications.error(__("There was an error opening the console"));
+      EventNotifications.error(__("There was an error opening the console"));
       logger.error(__("There was an error opening the console:"), error);
     }
 
@@ -72,7 +72,7 @@
           openRemote(results);
           break;
         default:
-          Notifications.error(__("Unsupported console protocol returned"));
+          EventNotifications.error(__("Unsupported console protocol returned"));
           logger.error(__("Unsupported console protocol returned:"), results.proto);
       }
     }

--- a/client/app/services/designer-state.service.js
+++ b/client/app/services/designer-state.service.js
@@ -5,7 +5,7 @@
       .factory('DesignerState', DesignerStateFactory);
 
   /** @ngInject */
-  function DesignerStateFactory($filter, CollectionsApi, Notifications, $state, sprintf, $q) {
+  function DesignerStateFactory($filter, CollectionsApi, $state, sprintf, $q) {
     var designer = {};
 
     designer.getDesignerToolboxTabs = function(srvTemplates) {

--- a/client/app/services/dialog-field-refresh.service.js
+++ b/client/app/services/dialog-field-refresh.service.js
@@ -6,7 +6,7 @@
     .factory('DialogFieldRefresh', DialogFieldRefreshFactory);
 
   /** @ngInject */
-  function DialogFieldRefreshFactory(CollectionsApi, Notifications) {
+  function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
     var service = {
       listenForAutoRefreshMessages: listenForAutoRefreshMessages,
       refreshSingleDialogField: refreshSingleDialogField,
@@ -48,7 +48,7 @@
       }
 
       function refreshFailure(result) {
-        Notifications.error('There was an error refreshing this dialog: ' + result);
+        EventNotifications.error('There was an error refreshing this dialog: ' + result);
       }
 
       dialogField.beingRefreshed = true;
@@ -101,7 +101,7 @@
       }
 
       function refreshFailure(result) {
-        Notifications.error('There was an error automatically refreshing dialogs' + result);
+        EventNotifications.error('There was an error automatically refreshing dialogs' + result);
       }
 
       fetchDialogFieldInfo(allDialogFields, fieldNamesToRefresh, url, resourceId, refreshSuccess, refreshFailure);

--- a/client/app/services/event-notifications.service.js
+++ b/client/app/services/event-notifications.service.js
@@ -1,0 +1,251 @@
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+  .factory('EventNotifications', EventNotificationsFactory);
+
+  /** @ngInject */
+  function EventNotificationsFactory($timeout) {
+    var state = {};
+    var toastDelay = 8 * 1000;
+
+    var service = {
+      add: add,
+      info: addInfo,
+      success: addSuccess,
+      error: addError,
+      warn: addWarn,
+      update: update,
+      markRead: markRead,
+      markUnread: markUnread,
+      markAllRead: markAllRead,
+      markAllUnread: markAllUnread,
+      clear: clear,
+      clearAll: clearAll,
+      showToast: showToast,
+      removeToast: removeToast,
+      setViewingToast: setViewingToast,
+      dismissToast: dismissToast,
+      state: function() {
+        return state;
+      }
+    };
+
+    var updateUnreadCount = function(group) {
+      if (group) {
+        group.unreadCount = group.notifications.filter(function(notification) {
+          return notification.unread;
+        }).length;
+        state.unreadNotifications = state.groups.find(function(group) {
+            return group.unreadCount > 0;
+          }) !== undefined;
+      }
+    };
+
+    doReset();
+
+    return service;
+
+    function doReset() {
+      state.groups = [
+        {
+          notificationType: 'event',
+          heading: "Events",
+          unreadCount: 0,
+          notifications: []
+        }
+      ];
+      state.unreadNotifications = false;
+      state.toastNotifications = [];
+    }
+
+    function add(notificationType, type, message, notificationData, id) {
+      var newNotification = {
+        id: id,
+        notificationType: notificationType,
+        unread: true,
+        type: type,
+        message: message,
+        data: notificationData,
+        timeStamp: (new Date()).getTime()
+      };
+
+      var group = state.groups.find(function(notificationGroup) {
+        return notificationGroup.notificationType === notificationType;
+      });
+
+      if (group) {
+        if (group.notifications) {
+          group.notifications.splice(0, 0, newNotification);
+        } else {
+          group.notifications = [newNotification];
+        }
+        updateUnreadCount(group);
+      }
+      showToast(newNotification);
+    }
+
+    function addInfo(message, notificationData, id) {
+      service.add('event', 'info', message, notificationData, id);
+    }
+
+    function addSuccess(message, notificationData, id) {
+      service.add('event', 'success', message, notificationData, id);
+    }
+
+    function addError(message, notificationData, id) {
+      service.add('event', 'danger', message, notificationData, id);
+    }
+
+    function addWarn(message, notificationData, id) {
+      service.add('event', 'warning', message, notificationData, id);
+    }
+
+    function update(notificationType, type, message, notificationData, id, showToast) {
+      var notification;
+      var group = state.groups.find(function(notificationGroup) {
+        return notificationGroup.notificationType === notificationType;
+      });
+
+      if (group) {
+        notification = group.notifications.find(function(notification) {
+          return notification.id === id;
+        });
+
+        if (notification) {
+          if (showToast) {
+            notification.unread = true;
+          }
+          notification.type = type;
+          notification.message = message;
+          notification.data = notificationData;
+          notification.timeStamp = (new Date()).getTime();
+          updateUnreadCount(group);
+        }
+      }
+
+      if (showToast) {
+        if (!notification) {
+          notification = {
+            type: type,
+            message: message
+          };
+        }
+
+        showToast(notification);
+      }
+    }
+
+    function markRead(notification, group) {
+      if (notification) {
+        notification.unread = false;
+        service.removeToast(notification);
+      }
+      if (group) {
+        updateUnreadCount(group);
+      } else {
+        state.groups.forEach(function(group) {
+          updateUnreadCount(group);
+        });
+      }
+    }
+
+    function markUnread(notification, group) {
+      if (notification) {
+        notification.unread = true;
+      }
+      if (group) {
+        updateUnreadCount(group);
+      } else {
+        state.groups.forEach(function(group) {
+          updateUnreadCount(group);
+        });
+      }
+    }
+
+    function markAllRead(group) {
+      if (group) {
+        group.notifications.forEach(function(notification) {
+          notification.unread = false;
+          service.removeToast(notification);
+        });
+        group.unreadCount = 0;
+      }
+    }
+
+    function markAllUnread(group) {
+      if (group) {
+        group.notifications.forEach(function(notification) {
+          notification.unread = true;
+        });
+        group.unreadCount = group.notifications.length;
+      }
+    }
+
+    function clear(notification, group) {
+      var index;
+
+      if (!group) {
+        group = state.groups.find(function(nextGroup) {
+          return notification.notificationType === nextGroup.notificationType;
+        });
+      }
+
+      if (group) {
+        index = group.notifications.indexOf(notification);
+        if (index > -1) {
+          group.notifications.splice(index, 1);
+          service.removeToast(notification);
+          updateUnreadCount(group);
+        }
+      }
+    }
+
+    function clearAll(group) {
+      if (group) {
+        angular.forEach(group.notifications, function(notification) {
+          service.removeToast(notification);
+        });
+        group.notifications = [];
+        updateUnreadCount(group);
+      }
+    }
+
+    function removeToast(notification) {
+      var index = state.toastNotifications.indexOf(notification);
+      if (index > -1) {
+        state.toastNotifications.splice(index, 1);
+      }
+    }
+
+    function showToast(notification) {
+      notification.show = true;
+      notification.persistent = notification.type === 'danger' || notification.type === 'error';
+      state.toastNotifications.push(notification);
+
+      // any toast notifications with out 'danger' or 'error' status are automatically removed after a delay
+      if (!notification.persistent) {
+        notification.viewing = false;
+        $timeout(function() {
+          notification.show = false;
+          if (!notification.viewing) {
+            removeToast(notification);
+          }
+        }, toastDelay);
+      }
+    }
+
+    function setViewingToast(notification, viewing) {
+      notification.viewing = viewing;
+      if (!viewing && !notification.show) {
+        removeToast(notification);
+      }
+    }
+
+    function dismissToast(notification) {
+      notification.show = false;
+      removeToast(notification);
+      service.markRead(notification);
+    }
+  }
+})();

--- a/client/app/services/rules-state.service.js
+++ b/client/app/services/rules-state.service.js
@@ -5,7 +5,7 @@
       .factory('RulesState', RulesStateFactory);
 
   /** @ngInject */
-  function RulesStateFactory(CollectionsApi, Notifications, $state, sprintf, $q, $timeout) {
+  function RulesStateFactory(CollectionsApi, EventNotifications, $state, sprintf, $q, $timeout) {
     var ruleState = {};
 
     ruleState.editRule = null;
@@ -65,12 +65,12 @@
       CollectionsApi.post('arbitration_rules', null, {}, ruleObj).then(createSuccess, createFailure);
 
       function createSuccess(response) {
-        Notifications.success(__(sprintf("The rule was created.")));
+        EventNotifications.success(__(sprintf("The rule was created.")));
         deferred.resolve(response.results[0].id);
       }
 
       function createFailure() {
-        Notifications.error(__('There was an error creating this rule.'));
+        EventNotifications.error(__('There was an error creating this rule.'));
         deferred.reject();
       }
 
@@ -85,7 +85,7 @@
       };
 
       var editFailure = function() {
-        Notifications.error(__('There was an error updating the rules.'));
+        EventNotifications.error(__('There was an error updating the rules.'));
         deferred.reject();
       };
 
@@ -129,12 +129,12 @@
       CollectionsApi.post('arbitration_rules', null, {}, ruleObj).then(deleteSuccess, deleteFailure);
 
       function deleteSuccess() {
-        Notifications.success(__('Rule(s) were succesfully deleted.'));
+        EventNotifications.success(__('Rule(s) were succesfully deleted.'));
         deferred.resolve();
       }
 
       function deleteFailure() {
-        Notifications.error(__('There was an error deleting the rule(s).'));
+        EventNotifications.error(__('There was an error deleting the rule(s).'));
         deferred.reject();
       }
 

--- a/client/app/states/designer/blueprints/editor/editor.html
+++ b/client/app/states/designer/blueprints/editor/editor.html
@@ -14,8 +14,6 @@
             </button>
         </li>
     </ol>
-
-    <pf-notification-list></pf-notification-list>
   </span>
 
   <div class="blueprint-designer-container">

--- a/client/app/states/designer/blueprints/editor/save-blueprint-modal-service.factory.js
+++ b/client/app/states/designer/blueprints/editor/save-blueprint-modal-service.factory.js
@@ -33,7 +33,7 @@
   }
 
   /** @ngInject */
-  function SaveBlueprintModalController(blueprint, toState, toParams, fromState, fromParams, $state, $modalInstance, BlueprintsState, Notifications) {
+  function SaveBlueprintModalController(blueprint, toState, toParams, fromState, fromParams, $state, $modalInstance, BlueprintsState) {
     var vm = this;
     vm.blueprint = blueprint;
     vm.save = save;

--- a/client/app/states/designer/blueprints/list/list.html
+++ b/client/app/states/designer/blueprints/list/list.html
@@ -1,7 +1,6 @@
 <div pf-toolbar id="blueprintToolbar" config="vm.toolbarConfig"></div>
 
 <div class="list-view-container">
-  <pf-notification-list></pf-notification-list>
   <div pf-list-view id="blueprintList" class="blueprints-list" config="vm.listConfig" items="vm.blueprintsList"
        action-buttons="vm.actionButtons"
        enable-button-for-item-fn="vm.enableButtonForItemFn"

--- a/client/app/states/designer/blueprints/list/list.state.js
+++ b/client/app/states/designer/blueprints/list/list.state.js
@@ -58,7 +58,7 @@
 
   /** @ngInject */
   function StateController($state, blueprints, BlueprintsState, serviceCatalogs, tenants, BlueprintDetailsModal, BlueprintDeleteModal,
-                           Notifications, $rootScope, Language) {
+                           EventNotifications, $rootScope, Language) {
     /* jshint validthis: true */
     var vm = this;
     var categoryNames = [];
@@ -231,13 +231,13 @@
     }
 
     function duplicateBlueprint(action, item) {
-      Notifications.error(__('Duplicate blueprint feature not available.'), false, false);
+      EventNotifications.error(__('Duplicate blueprint feature not available.'));
       $state.go($state.current, {}, {reload: true});
     }
 
     function publishBlueprint(action, item) {
       if (item.ui_properties.num_items === 0) {
-        Notifications.error(__('Cannot publish a blueprint with no service items.'), false, false);
+        EventNotifications.error(__('Cannot publish a blueprint with no service items.'));
 
         // Make sure all notifications disappear after delay
         if (angular.isDefined($rootScope.notifications) && $rootScope.notifications.data.length > 0) {

--- a/client/app/states/designer/blueprints/list/list.state.js
+++ b/client/app/states/designer/blueprints/list/list.state.js
@@ -86,13 +86,6 @@
       visibilityNames.push(item.name);
     }
 
-    /* This notification 'splice' code doesn't work.  Splice needs a third argument, the items to splice in
-     * Not sure what this code is trying to accomplish, but it exists in login, request list, & services list
-    if (angular.isDefined($rootScope.notifications) && $rootScope.notifications.data.length > 0) {
-      $rootScope.notifications.data.splice(0, $rootScope.notifications.data.length);
-    }
-    */
-
     vm.blueprintsList = angular.copy(vm.blueprints);
 
     vm.listConfig = {

--- a/client/app/states/designer/rules/rules.html
+++ b/client/app/states/designer/rules/rules.html
@@ -7,8 +7,6 @@
       <li class="active"><strong>{{'Rules' | translate}}</strong>
       </li>
     </ol>
-
-    <pf-notification-list></pf-notification-list>
   </span>
   <div pf-toolbar class="designer-rules-toolbar" id="designerRulesToolbar" config="vm.toolbarConfig">
     <actions>

--- a/client/app/states/marketplace/details/details.html
+++ b/client/app/states/marketplace/details/details.html
@@ -6,8 +6,6 @@
   </li>
 </ol>
 
-<pf-notification-list></pf-notification-list>
-
 <div class="ss-details-wrapper">
   <div class="panel panel-default ss-details-panel">
     <div class="panel-body">

--- a/client/app/states/marketplace/details/details.state.js
+++ b/client/app/states/marketplace/details/details.state.js
@@ -40,7 +40,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, CollectionsApi, dialogs, serviceTemplate, Notifications, DialogFieldRefresh, ShoppingCart) {
+  function StateController($state, CollectionsApi, dialogs, serviceTemplate, EventNotifications, DialogFieldRefresh, ShoppingCart) {
     var vm = this;
 
     vm.serviceTemplate = serviceTemplate;
@@ -97,13 +97,13 @@
       .then(addSuccess, addFailure);
 
       function addSuccess(result) {
-        Notifications.success(__("Item added to shopping cart"));
+        EventNotifications.success(__("Item added to shopping cart"));
       }
 
       function addFailure(result) {
         var errors = result.split(",");
         for (var i = 0; i<errors.length; ++i) {
-          Notifications.error(__("There was an error adding to shopping cart: ") + errors[i]);
+          EventNotifications.error(__("There was an error adding to shopping cart: ") + errors[i]);
         }
       }
     }

--- a/client/app/states/requests/list/list.html
+++ b/client/app/states/requests/list/list.html
@@ -2,16 +2,12 @@
   <tab heading="{{'My Requests' | translate}}">
     <div pf-toolbar id="requestToolbar" config="vm.toolbarConfig"></div>
 
-    <pf-notification-list></pf-notification-list>
-
     <div class="list-view-container -in-a-tab">
       <request-list items="vm.requestsList" config="vm.listConfig"></request-list>
     </div>
   </tab>
   <tab heading="{{'My Orders' | translate}}">
     <div pf-toolbar config="vm.orderToolbarConfig"></div>
-
-    <pf-notification-list></pf-notification-list>
 
     <div class="list-view-container -in-a-tab -without-toolbar">
       <div pf-list-view id="orderList" config="vm.orderListConfig" items="vm.ordersList">

--- a/client/app/states/services/custom_button_details/custom_button_details.html
+++ b/client/app/states/services/custom_button_details/custom_button_details.html
@@ -10,8 +10,6 @@
   <li class="active"> <strong translate>Custom Button:</strong> {{ ::vm.button.name }} </li>
 </ol>
 
-<pf-notification-list></pf-notification-list>
-
 <div class="panel panel-default ss-details-panel">
   <div class="panel-body">
     <section>

--- a/client/app/states/services/custom_button_details/custom_button_details.state.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.js
@@ -41,7 +41,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, $stateParams, dialog, service, CollectionsApi, Notifications, DialogFieldRefresh) {
+  function StateController($state, $stateParams, dialog, service, CollectionsApi, EventNotifications, DialogFieldRefresh) {
     var vm = this;
     vm.title = __('Custom button action');
     vm.dialogs = dialog.content;
@@ -85,12 +85,12 @@
       ).then(submitSuccess, submitFailure);
 
       function submitSuccess(result) {
-        Notifications.success(result.message);
+        EventNotifications.success(result.message);
         $state.go('services.details', {serviceId: $stateParams.serviceId});
       }
 
       function submitFailure(result) {
-        Notifications.error(__('There was an error submitting this request: ') + result);
+        EventNotifications.error(__('There was an error submitting this request: ') + result);
       }
     }
   }

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -7,8 +7,6 @@
 </ol>
 
 <div class="ss-details-wrapper">
-  <pf-notification-list></pf-notification-list>
-
   <div class="panel panel-default ss-details-panel">
     <div class="panel-body">
       <section>

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -52,7 +52,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, Notifications, jQuery, Consoles) {
+  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, EventNotifications, jQuery, Consoles) {
     var vm = this;
     setInitialVars(vm);
 
@@ -110,12 +110,12 @@
       CollectionsApi.post('services', vm.service.id, {}, removeAction).then(removeSuccess, removeFailure);
 
       function removeSuccess() {
-        Notifications.success(vm.service.name + __(' was removed.'));
+        EventNotifications.success(vm.service.name + __(' was removed.'));
         $state.go('services.list');
       }
 
       function removeFailure(data) {
-        Notifications.error(__('There was an error removing this service.'));
+        EventNotifications.error(__('There was an error removing this service.'));
       }
     }
 
@@ -149,12 +149,12 @@
       CollectionsApi.post('services', vm.service.id, {}, data).then(retireSuccess, retireFailure);
 
       function retireSuccess() {
-        Notifications.success(vm.service.name + __(' was retired.'));
+        EventNotifications.success(vm.service.name + __(' was retired.'));
         $state.go('services.list');
       }
 
       function retireFailure() {
-        Notifications.error(__('There was an error retiring this service.'));
+        EventNotifications.error(__('There was an error retiring this service.'));
       }
     }
 

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -1,7 +1,6 @@
 <div pf-toolbar id="serviceToolbar" config="vm.toolbarConfig"></div>
 
 <div class="list-view-container">
-  <pf-notification-list></pf-notification-list>
   <div pf-list-view id="serviceList" config="vm.listConfig" items="vm.servicesList">
     <div class="row">
       <div class="col-lg-3 col-md-4 col-sm-6 col-xs-6">

--- a/client/app/states/services/reconfigure/reconfigure.html
+++ b/client/app/states/services/reconfigure/reconfigure.html
@@ -6,8 +6,6 @@
   </li>
 </ol>
 
-<pf-notification-list></pf-notification-list>
-
 <div class="ss-details-wrapper">
   <div class="panel-body">
     <section>

--- a/client/app/states/services/reconfigure/reconfigure.state.js
+++ b/client/app/states/services/reconfigure/reconfigure.state.js
@@ -35,7 +35,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, $stateParams, CollectionsApi, service, Notifications, DialogFieldRefresh) {
+  function StateController($state, $stateParams, CollectionsApi, service, EventNotifications, DialogFieldRefresh) {
     var vm = this;
 
     vm.title = __('Service Details');
@@ -104,17 +104,17 @@
       ).then(submitSuccess, submitFailure);
 
       function submitSuccess(result) {
-        Notifications.success(result.message);
+        EventNotifications.success(result.message);
         $state.go('services.details', {serviceId: $stateParams.serviceId});
       }
 
       function submitFailure(result) {
-        Notifications.error(__('There was an error submitting this request: ') + result);
+        EventNotifications.error(__('There was an error submitting this request: ') + result);
       }
     }
 
     function cancelDialog() {
-      Notifications.success(__('Reconfigure this service has been cancelled'));
+      EventNotifications.success(__('Reconfigure this service has been cancelled'));
       $state.go('services.details', {serviceId: $stateParams.serviceId});
     }
   }

--- a/client/index.html
+++ b/client/index.html
@@ -172,6 +172,7 @@
   <script src="/client/app/services/consoles.service.js"></script>
   <script src="/client/app/services/designer-state.service.js"></script>
   <script src="/client/app/services/dialog-field-refresh.service.js"></script>
+  <script src="/client/app/services/event-notifications.service.js"></script>
   <script src="/client/app/services/language.service.js"></script>
   <script src="/client/app/services/marketplace-state.service.js"></script>
   <script src="/client/app/services/messages.service.js"></script>


### PR DESCRIPTION
This PR replaces the use of inline notifications and the Angular Patternfly Notifications service with a Notifications Drawer, Toast List, and EventNotifications service.

The inline messages are now shown as Toasts in the upper right section of the window and are then also available in the Notifications Drawer until removed by the user. The notifications shown in the drawer are for the current session only, there is no saving/retrieval of past notifications or notifications from other sessions.

Toasts:
![image](https://cloud.githubusercontent.com/assets/11633780/18549688/f96da25c-7b1d-11e6-9a01-eb9a55d74b10.png)

Notifications Drawer:
![image](https://cloud.githubusercontent.com/assets/11633780/18549708/10e58fb2-7b1e-11e6-971f-ffc0eec28a57.png)


@serenamarie125 @beanh66 @chriskacerguis @dtaylor113 