### PR TITLE
Updated gulp-clean-css to latest version, 1.0.0 doesn't even exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gulp-jscs": "^4.0.0",
     "gulp-jshint": "^2.0.1",
     "gulp-load-plugins": "^1.3.0",
-    "gulp-clean-css": "^1.0.0",
+    "gulp-clean-css": "^2.0.12",
     "gulp-minify-html": "^1.0.1",
     "gulp-ng-annotate": "^2.0.0",
     "gulp-nodemon": "^2.1.0",


### PR DESCRIPTION
Minor change, when switching the depreciated dependency I overlooked updating the version.