### PR TITLE
eslint camelcase violations, pt 1

### DIFF
--- a/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
+++ b/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: "off" */
 (function() {
   'use strict';
 

--- a/client/app/components/blueprint-details-modal/blueprint-order-list.service.js
+++ b/client/app/components/blueprint-details-modal/blueprint-order-list.service.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: "off" */
 (function() {
   'use strict';
 

--- a/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
+++ b/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: "off" */
 (function() {
   'use strict';
 

--- a/client/app/services/blueprints-state.service.js
+++ b/client/app/services/blueprints-state.service.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: "off" */
 (function() {
   'use strict';
 

--- a/client/app/services/rules-state.service.js
+++ b/client/app/services/rules-state.service.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: "off" */
 (function() {
   'use strict';
 

--- a/client/app/states/designer/blueprints/list/list.state.js
+++ b/client/app/states/designer/blueprints/list/list.state.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: "off" */
 (function() {
   'use strict';
 

--- a/client/app/states/designer/rules/rules.state.js
+++ b/client/app/states/designer/rules/rules.state.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: "off" */
 (function() {
   'use strict';
 

--- a/client/app/states/marketplace/list/list.state.js
+++ b/client/app/states/marketplace/list/list.state.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: "off" */
 (function() {
   'use strict';
 


### PR DESCRIPTION
Breaking up the eslint camelcase fixes into multiple PRs. This edition includes ignoring the camelcase violoations in files where there are snake case variables which should not be changed, IE when creating an options query such as:

```
  function resolveServiceCatalogs(CollectionsApi) {
    var options = {
      expand: 'resources',
      sort_by: 'name',
      sort_options: 'ignore_case'
    };

    return CollectionsApi.query('service_catalogs', options);
  }
```

**or** 

setting a property such as `ui_properties` on a Blueprint.

Went through these files carefully to ensure I didn't miss anything that *could* be changed. Do not believe I missed any. 

#121 
cc: @AllenBW @chriskacerguis 