### PR TITLE
Updated Toolbox Tabs and Items can only be added once to Canvas

### DIFF
--- a/client/app/components/blueprint-delete-modal/blueprint-delete-modal-service.factory.js
+++ b/client/app/components/blueprint-delete-modal/blueprint-delete-modal-service.factory.js
@@ -31,7 +31,7 @@
   }
 
   /** @ngInject */
-  function BlueprintDeleteModalController(blueprints, BlueprintsState, $state, $modalInstance, CollectionsApi) {
+  function BlueprintDeleteModalController(blueprints, BlueprintsState, $state, $modalInstance, $log, CollectionsApi) {
     var vm = this;
 
     vm.blueprintsList = blueprints;
@@ -51,7 +51,7 @@
       }
 
       function deleteFailure() {
-        console.log("Failed to delete blueprint(s).");
+        $log.error("Failed to delete blueprint(s).");
         $modalInstance.close();
       }
     }

--- a/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
+++ b/client/app/components/blueprint-details-modal/blueprint-details-modal-service.factory.js
@@ -169,7 +169,7 @@
         for (var i = 0; i < vm.blueprint.content.automate_entrypoints.length; i++) {
           var aep = vm.blueprint.content.automate_entrypoints[i];
           var newAepStr = BlueprintsState.getEntryPointString(aep);
-          // console.log("modal data = " + aep.action + ": " + newAepStr);
+          // $log.debug("modal data = " + aep.action + ": " + newAepStr);
           var newAepObj = {action: aep.action, index: i, value: newAepStr};
           switch (aep.action) {
             case "Provision":
@@ -202,7 +202,6 @@
       var modalInstance = CreateCatalogModal.showModal();
 
       modalInstance.then(function(opts) {
-        console.log("New Catalog Name is '" + opts.catalogName + "'");
         angular.element( "#createCatalog" ).blur();
       });
     }
@@ -306,9 +305,9 @@
       }
 
       /*
-      console.log("Orig Blueprint = " + angular.toJson(BlueprintsState.getOriginalBlueprint().content, true));
-      console.log("Updated Blueprint = " + angular.toJson(vm.blueprint.content, true));
-      console.log("Diff = " + angular.toJson(BlueprintsState.difference(vm.blueprint.content,
+       $log.debug("Orig Blueprint = " + angular.toJson(BlueprintsState.getOriginalBlueprint().content, true));
+       $log.debug("Updated Blueprint = " + angular.toJson(vm.blueprint.content, true));
+       $log.debug("Diff = " + angular.toJson(BlueprintsState.difference(vm.blueprint.content,
                   BlueprintsState.getOriginalBlueprint().content), true));
       */
 
@@ -351,7 +350,7 @@
         var instance = (parts.length ? parts.splice(-1, 1)[0] : "");
         var clazz = (parts.length ? parts.splice(-1, 1)[0] : "");
         var namespace = parts.join("\/");
-        // console.log("blueprint data = " + modalData.action + " - " + namespace + ":" + clazz + ":" + instance);
+        // $log.debug("blueprint data = " + modalData.action + " - " + namespace + ":" + clazz + ":" + instance);
         if (angular.isDefined(modalData.index)) {
           var bpAEP = vm.blueprint.content.automate_entrypoints[modalData.index];
           if (angular.isUndefined(bpAEP.ae_class) && angular.isUndefined(bpAEP.ae_instance) && angular.isUndefined(bpAEP.ae_namespace )) {
@@ -368,7 +367,7 @@
           }
         } else {
           if (namespace.length || clazz.length || instance.length) {
-            // console.log("Adding new entry point");
+            // $log.debug("Adding new entry point");
             vm.blueprint.content.automate_entrypoints.push({
               action: modalData.action,
               ae_namespace: namespace,

--- a/client/app/components/browse-entry-point-modal/browse-entry-point-modal-service.factory.js
+++ b/client/app/components/browse-entry-point-modal/browse-entry-point-modal-service.factory.js
@@ -31,7 +31,7 @@
   }
 
   /** @ngInject */
-  function BrowseEntryPointModalController(entryPointType, $state, $modalInstance) {
+  function BrowseEntryPointModalController(entryPointType, $state, $modalInstance, $log) {
     var vm = this;
     vm.entryPointType = entryPointType;
 
@@ -68,7 +68,7 @@
           }
           $modalInstance.close({entryPointType: vm.entryPointType, entryPointData: pathToNode});
         } else {
-          console.log("No " + vm.entryPointTypeTitle + " Entry Point selected.");
+          $log.warn("No " + vm.entryPointTypeTitle + " Entry Point selected.");
         }
       }
     }

--- a/client/app/components/create-catalog-modal/create-catalog-modal-service.factory.js
+++ b/client/app/components/create-catalog-modal/create-catalog-modal-service.factory.js
@@ -25,7 +25,7 @@
   }
 
   /** @ngInject */
-  function CreateCatalogModalController($state, $modalInstance) {
+  function CreateCatalogModalController($state, $modalInstance, $log) {
     var vm = this;
 
     vm.modalData = {
@@ -41,7 +41,7 @@
         if (vm.modalData.catalogName && vm.modalData.catalogName.length > 0) {
           $modalInstance.close({catalogName: vm.modalData.catalogName});
         } else {
-          console.log("Catalog Name not provided.");
+          $log.error("Catalog Name not provided.");
         }
       }
     }

--- a/client/app/components/flowchart/flowchart_template.html
+++ b/client/app/components/flowchart/flowchart_template.html
@@ -86,8 +86,9 @@
       </g>
       <foreignobject ng-attr-x="{{node.x}}"
                      ng-attr-y="{{node.height()+1}}"
-                     ng-attr-width="{{node.width()}}"
-                     ng-mousedown="$event.stopPropagation()">
+                     ng-mousedown="$event.stopPropagation()"
+                     height="100%"
+                     width="100%">
         <body>
           <node-toolbar node="node" node-actions="chart.nodeActions"/>
         </body>

--- a/client/app/components/flowchart/flowchart_template.html
+++ b/client/app/components/flowchart/flowchart_template.html
@@ -64,7 +64,7 @@
           class="node-center-icon"
           ng-class="{'invalid-node-header': node.invalid()}"
           font-family="{{node.fontFamily()}}"
-          ng-attr-x="{{(node.width()/2) - 40 + ((node.bundle()) ? 11 : 0) }}"
+          ng-attr-x="{{(node.width()/2) - 40 + ((node.bundle()) ? 4 : 0) }}"
           ng-attr-y="{{90}}">
       {{node.fontContent()}}
     </text>
@@ -73,9 +73,9 @@
     <g><text ng-if="node.bundle()"
              x="6"
              y="22"
-             font-family="FontAwesome"
+             font-family="PatternFlyIcons-webfont"
              font-size="20">
-         {{'\uf06b'}}
+         {{'\ue918'}}
        </text>
     </g>
 

--- a/client/app/components/flowchart/node-toolbar.html
+++ b/client/app/components/flowchart/node-toolbar.html
@@ -1,4 +1,4 @@
-<div class="node-toolbar">
+<div class="node-toolbar" ng-style="{width: vm.node.width()}">
   <span ng-repeat="nodeAction in vm.nodeActions"
         class="{{nodeAction.iconClass()}} node-toolbar-icons"
         ng-click="actionIconClicked(nodeAction.action())">

--- a/client/app/components/tagging/tagging.directive.js
+++ b/client/app/components/tagging/tagging.directive.js
@@ -22,7 +22,7 @@
     return directive;
 
     /** @ngInject */
-    function TaggingController($scope, $filter, $q, CollectionsApi) {
+    function TaggingController($scope, $filter, $q, $log, CollectionsApi) {
       var vm = this;
 
       if (!vm.tags) {
@@ -78,7 +78,7 @@
         }
 
         function loadFailure() {
-          console.log('There was an error loading all tags.');
+          $log.error('There was an error loading all tags.');
           deferred.reject();
         }
 
@@ -101,7 +101,7 @@
         }
 
         function loadFailure() {
-          console.log('There was an error loading categories.');
+          $log.error('There was an error loading categories.');
           deferred.reject();
         }
 
@@ -127,7 +127,7 @@
         }
 
         function loadFailure() {
-          console.log('There was an error loading ' + vm.objectType + ', id = ' + vm.objectId);
+          $log.error('There was an error loading ' + vm.objectType + ', id = ' + vm.objectId);
           deferred.reject();
         }
 

--- a/client/app/resources/collections-api.factory.js
+++ b/client/app/resources/collections-api.factory.js
@@ -17,7 +17,7 @@
     function query(collection, options) {
       var url = API_BASE + '/api/' + collection;
 
-      // console.log("query = " + url + buildQuery(options));
+      // $log.debug("query = " + url + buildQuery(options));
 
       return $http.get(url + buildQuery(options), buildConfig(options))
         .then(handleSuccess);
@@ -30,7 +30,7 @@
     function get(collection, id, options) {
       var url = API_BASE + '/api/' + collection + '/' + id;
 
-      // console.log("get = " + url + buildQuery(options));
+      // $log.debug("get = " + url + buildQuery(options));
 
       return $http.get(url + buildQuery(options), buildConfig(options))
         .then(handleSuccess);
@@ -43,7 +43,7 @@
     function post(collection, id, options, data) {
       var url = API_BASE + '/api/' + collection + '/' + (id || "") + buildQuery(options);
 
-      // console.log("post = " + url + buildQuery(options));
+      // $log.debug("post = " + url + buildQuery(options));
 
       return $http.post(url, data, buildConfig(options))
         .then(handleSuccess);

--- a/client/app/services/blueprints-state.service.js
+++ b/client/app/services/blueprints-state.service.js
@@ -6,7 +6,7 @@
     .factory('BlueprintsState', BlueprintsStateFactory);
 
   /** @ngInject */
-  function BlueprintsStateFactory($filter, CollectionsApi, EventNotifications, $state, sprintf, $q) {
+  function BlueprintsStateFactory(CollectionsApi, EventNotifications, $log, $q) {
     var blueprint = {};
 
     blueprint.sort = {
@@ -81,11 +81,11 @@
       var deferred = $q.defer();
 
       saveBlueprintProperties(tmpBlueprint).then(function(id) {
-        console.log("'" + tmpBlueprint.name + "' Blueprint Properties were saved.");
+        $log.info("'" + tmpBlueprint.name + "' Blueprint Properties were saved.");
         saveBlueprintTags(id, tmpBlueprint).then(function() {
-          console.log("'" + tmpBlueprint.name + "' Blueprint Tags were saved.");
+          $log.info("'" + tmpBlueprint.name + "' Blueprint Tags were saved.");
           saveBlueprintServiceItemTags(tmpBlueprint).then(function() {
-            console.log("'" + tmpBlueprint.name + "' Blueprint Service Item Tags were saved.");
+            $log.info("'" + tmpBlueprint.name + "' Blueprint Service Item Tags were saved.");
             deferred.resolve(id);
           }, saveServiceItemTagsfailure);
         }, saveTagsfailure);
@@ -117,7 +117,7 @@
 
       var blueprintObj = getBlueprintPostObj(tmpBlueprint);
 
-      // console.log("Saving Blueprint: " + angular.toJson(blueprintObj, true));
+      // $log.debug("Saving Blueprint: " + angular.toJson(blueprintObj, true));
 
       if (tmpBlueprint.id) {
         CollectionsApi.post('blueprints', tmpBlueprint.id, {}, blueprintObj).then(updateSuccess, updateFailure);
@@ -130,7 +130,7 @@
       }
 
       function updateFailure() {
-        console.log('There was an error saving this blueprints properties.');
+        $log.error('There was an error saving this blueprints properties.');
         deferred.reject();
       }
 
@@ -139,7 +139,7 @@
       }
 
       function createFailure() {
-        console.log('There was an error creating this blueprint.');
+        $log.error('There was an error creating this blueprint.');
         deferred.reject();
       }
 
@@ -231,10 +231,10 @@
 
       if (assignObj.resources.length > 0) {
         CollectionsApi.post(collection, null, {}, assignObj).then(function() {
-          console.log("  Blueprint tags assigned succesfully.");
+          $log.info("  Blueprint tags assigned succesfully.");
           if (unassignObj.resources.length > 0) {
             CollectionsApi.post(collection, null, {}, unassignObj).then(function() {
-              console.log("  Blueprint tags unassigned succesfully.");
+              $log.info("  Blueprint tags unassigned succesfully.");
               deferred.resolve();
             }, assignFailure);
           } else {
@@ -244,7 +244,7 @@
       } else {
         if (unassignObj.resources.length > 0) {
           CollectionsApi.post(collection, null, {}, unassignObj).then(function() {
-            console.log("  Blueprint tags unassigned succesfully.");
+            $log.info("  Blueprint tags unassigned succesfully.");
             deferred.resolve();
           }, assignFailure);
         } else {
@@ -253,12 +253,12 @@
       }
 
       function assignFailure() {
-        console.log('There was an error assigning blueprint tags.');
+        $log.error('There was an error assigning blueprint tags.');
         deferred.reject();
       }
 
       function unassignFailure() {
-        console.log('There was an error unassigning blueprint tags.');
+        $log.error('There was an error unassigning blueprint tags.');
         deferred.reject();
       }
 
@@ -281,18 +281,18 @@
           }
           if (promises.length > 0) {
             $q.all(promises).then(function(ids) {
-              console.log("    Saved Service Item Tags for " + ids);
+              $log.debug("    Saved Service Item Tags for " + ids);
               deferred.resolve();
             }, function(ids) {
-              console.log("    Failed to save Service Item Tags for " + ids);
+              $log.debug("    Failed to save Service Item Tags for " + ids);
               deferred.reject();
             });
           } else {
-            console.log("    No Tags to save for Service Items");
+            $log.debug("    No Tags to save for Service Items");
             deferred.resolve();
           }
         } else {
-          console.log("    No Service Items to save tags for");
+          $log.debug("    No Service Items to save tags for");
           deferred.resolve();
         }
       }
@@ -310,26 +310,26 @@
 
       if (assignObj.resources.length > 0) {
         CollectionsApi.post(collection, null, {}, assignObj).then(function() {
-          console.log("    Service Item tags assigned succesfully for " + id);
+          $log.info("    Service Item tags assigned succesfully for " + id);
           if (unassignObj.resources.length > 0) {
             CollectionsApi.post(collection, null, {}, unassignObj).then(function() {
-              console.log("    Service Item tags unassigned succesfully for " + id);
+              $log.info("    Service Item tags unassigned succesfully for " + id);
               deferred.resolve(id);
             }, assignFailure);
           } else {
-            console.log("    No unassigned tags for Service Item " + id);
+            $log.debug("    No unassigned tags for Service Item " + id);
             deferred.resolve(id);
           }
         }, unassignFailure);
       } else {
-        console.log("    No assigned tags for Service Item " + id);
+        $log.debug("    No assigned tags for Service Item " + id);
         if (unassignObj.resources.length > 0) {
           CollectionsApi.post(collection, null, {}, unassignObj).then(function() {
-            console.log("    Service Item tags unassigned succesfully for " + id);
+            $log.debug("    Service Item tags unassigned succesfully for " + id);
             deferred.resolve(id);
           }, assignFailure);
         } else {
-          console.log("    No unassigned tags for Service Item " + id);
+          $log.debug("    No unassigned tags for Service Item " + id);
           deferred.resolve(id);
         }
       }
@@ -375,7 +375,7 @@
           }
         }
         if (!foundInOther) {
-          // console.log("--> " + action + " " + tag.id + " - " + tag.categorization.display_name);
+          // $log.debug("--> " + action + " " + tag.id + " - " + tag.categorization.display_name);
           resources.push({id: tag.id});
         }
       }
@@ -456,7 +456,7 @@
 
       for (k in o1) {  // jshint ignore:line
         if (!o1.hasOwnProperty(k)) {
-          console.log("obj 2 doesn't have " + k);
+          $log.warn("obj 2 doesn't have " + k);
         } else if (!angular.isObject(o1[k]) || !angular.isObject(o2[k]) ) {
           if (!(k in o2) || o1[k] !== o2[k]) {
             diff[k] = o2[k];

--- a/client/app/services/designer-state.service.js
+++ b/client/app/services/designer-state.service.js
@@ -5,7 +5,7 @@
       .factory('DesignerState', DesignerStateFactory);
 
   /** @ngInject */
-  function DesignerStateFactory($filter, CollectionsApi, $state, sprintf, $q) {
+  function DesignerStateFactory($filter, $log) {
     var designer = {};
 
     designer.getDesignerToolboxTabs = function(srvTemplates) {
@@ -109,15 +109,15 @@
           if (srvTemplate.prov_type !== 'generic') {
             subTab = findSubTabByProvType(srvTemplate.prov_type);
             if (!subTab) {
-              console.log("Couldn't find toolbox Tab for Prov_Type: " + srvTemplate.prov_type);
+              $log.warn("Couldn't find toolbox Tab for Prov_Type: " + srvTemplate.prov_type);
             }
           } else if (srvTemplate.generic_subtype) {
             subTab = findSubTabByGenericSubType(srvTemplate.generic_subtype);
             if (!subTab) {
-              console.log("Couldn't find toolbox Tab for Generic_Subtype: " + srvTemplate.generic_subtype);
+              $log.warn("Couldn't find toolbox Tab for Generic_Subtype: " + srvTemplate.generic_subtype);
             }
           } else {
-            console.log("Error: No generic_subtype for Generic " + srvTemplate.name);
+            $log.error("Error: No generic_subtype for Generic " + srvTemplate.name);
           }
           if (subTab) {
             addToSubTab(subTab, srvTemplate);
@@ -198,7 +198,7 @@
         }
         bundleTab.items.push(newBundle);
         designer.tabItems.push(newBundle);
-        // console.log("--> Added " + newBundle.name + " to Bundle Tab");
+        // $log.debug("--> Added " + newBundle.name + " to Bundle Tab");
       }
 
       function addToSubTab(subTab, srvTemplate) {
@@ -216,7 +216,7 @@
         }
         subTab.items.push(newItem);
         designer.tabItems.push(newItem);
-        // console.log("--> Added " + newItem.name + " to " + subTab.title + " Tab");
+        // $log.debug("--> Added " + newItem.name + " to " + subTab.title + " Tab");
       }
     };
 

--- a/client/app/services/designer-state.service.js
+++ b/client/app/services/designer-state.service.js
@@ -9,6 +9,7 @@
     var designer = {};
 
     designer.getDesignerToolboxTabs = function(srvTemplates) {
+      designer.tabItems = [];
       var toolboxTabs = [
         {
           title: 'Compute',
@@ -67,7 +68,8 @@
           subtabs: [
             {
               title: 'Generic',
-              generic_subtype: 'storage'},
+              generic_subtype: 'storage'
+            },
           ],
         },
         {
@@ -75,7 +77,8 @@
           subtabs: [
             {
               title: 'Generic',
-              generic_subtype: 'load_balancer'},
+              generic_subtype: 'load_balancer'
+            },
           ],
         },
         {
@@ -185,11 +188,16 @@
           newBundle.image = srvTemplate.picture.image_href;
         }
 
+        if (srvTemplate.disableInToolbox !== undefined) {
+          newBundle.disableInToolbox = srvTemplate.disableInToolbox;
+        }
+
         var bundleTab = toolboxTabs[bundleTabIndex];
         if (!bundleTab.items) {
           bundleTab.items = [];
         }
         bundleTab.items.push(newBundle);
+        designer.tabItems.push(newBundle);
         // console.log("--> Added " + newBundle.name + " to Bundle Tab");
       }
 
@@ -200,12 +208,22 @@
         } else {
           newItem.image = "images/service.png";
         }
+        if (srvTemplate.disableInToolbox !== undefined) {
+          newItem.disableInToolbox = srvTemplate.disableInToolbox;
+        }
         if (!subTab.items) {
           subTab.items = [];
         }
         subTab.items.push(newItem);
+        designer.tabItems.push(newItem);
         // console.log("--> Added " + newItem.name + " to " + subTab.title + " Tab");
       }
+    };
+
+    designer.getTabItemById = function(id) {
+      var tabItems = $filter('filter')(designer.tabItems, {id: id});
+
+      return tabItems[0];
     };
 
     return designer;

--- a/client/app/states/administration/rules/rules.state.js
+++ b/client/app/states/administration/rules/rules.state.js
@@ -44,7 +44,7 @@
   }
 
   /** @ngInject */
-  function RulesController(arbitrationRules, fields, profiles, RulesState, SaveRuleModal, $state, $scope, $timeout) {
+  function RulesController(arbitrationRules, fields, profiles, RulesState, SaveRuleModal, $state, $scope, $timeout, $log) {
     /* jshint validthis: true */
     var vm = this;
     vm.operators = [
@@ -384,7 +384,7 @@
       updateRulesPriorities(true);
     };
     vm.dropCallback = function(event, ui, item, index) {
-      console.log("Dropped " + item.value + " at index " + index);
+      $log.debug("Dropped " + item.value + " at index " + index);
     };
     vm.toolbarConfig = {
       actionsConfig: {

--- a/client/app/states/designer/blueprints/editor/_editor.sass
+++ b/client/app/states/designer/blueprints/editor/_editor.sass
@@ -139,6 +139,11 @@
           bottom: 4px
           width: 10px
 
+      .not-draggable
+        opacity: 0.4
+        background-color: #ededed
+        cursor: auto
+
       .toolbox-footer
         width: 90%
         margin-top: 10px

--- a/client/app/states/designer/blueprints/editor/_editor.sass
+++ b/client/app/states/designer/blueprints/editor/_editor.sass
@@ -68,6 +68,12 @@
       padding-right: 26px
       padding-bottom: 10px
 
+      .draggable-item-icon
+        font-size: 28px
+        vertical-align: middle
+        padding-top: 6px
+        padding-right: 6px
+
       .tab-pre-title
         font-size: 12px
         margin-bottom: -6px
@@ -134,11 +140,11 @@
           width: 10px
 
       .toolbox-footer
+        width: 90%
         margin-top: 10px
         margin-bottom: 10px
-        margin-left: 15px
+        margin-left: 2px
         margin-right: 184px
-        display: initial
 
         .new-catalog-item
           border: 2px dashed #bbb
@@ -165,17 +171,17 @@
             font-size: 12px
 
         .search-text
+          position: relative
           border: 1px solid #bbb
           float: right
-          margin-top: -38px
-          padding-left: 6px
           width: 14%
           text-decoration: none
 
         .clear-search-text
-          position: absolute
-          bottom: 75px
-          right: 33px
+          position: relative
+          float: right
+          bottom: -6px
+          right: -197px
           color: #bbb
           cursor: pointer
 
@@ -186,6 +192,7 @@
 
       .close-toolbox
         text-align: center
+        padding-top: 36px
 
     .canvas-container
       width: 99%

--- a/client/app/states/designer/blueprints/editor/canvasCtrl.js
+++ b/client/app/states/designer/blueprints/editor/canvasCtrl.js
@@ -2,10 +2,10 @@
   "use strict";
 
   angular.module('app.states')
-    .controller('CanvasController', ['$scope', '$filter', StateController]);
+    .controller('CanvasController', ['$scope', '$filter', 'DesignerState', StateController]);
 
   /** @ngInject */
-  function StateController($scope, $filter) {
+  function StateController($scope, $filter, DesignerState) {
     var chartDataModel = {};
     var newNodeCount = 0;
     if ($scope.$parent.blueprint.ui_properties && $scope.$parent.blueprint.ui_properties.chart_data_model) {
@@ -27,6 +27,7 @@
     };
 
     $scope.dropCallback = function(event, ui) {
+      $scope.draggedItem.disableInToolbox = true;
       var newNode = angular.copy($scope.draggedItem);
       if (newNode.type && newNode.type === 'generic') {
         newNode.name = 'New ' + newNode.name;
@@ -39,6 +40,7 @@
     };
 
     $scope.addNodeByClick = function(item) {
+      item.disableInToolbox = true;
       var newNode = angular.copy(item);
       if (newNode.type && newNode.type === 'generic') {
         newNode.name = 'New ' + newNode.name;
@@ -81,6 +83,16 @@
     };
 
     $scope.deleteSelected = function() {
+      var selectedNodes = $scope.chartViewModel.getSelectedNodes();
+
+      // Re-Enable selectedNodes in toolbox
+      for (var i = 0; i < selectedNodes.length; i++) {
+        var tabItem = DesignerState.getTabItemById(selectedNodes[i].id());
+        if (tabItem) {
+          tabItem.disableInToolbox = false;
+        }
+      }
+
       $scope.chartViewModel.deleteSelected();
     };
 

--- a/client/app/states/designer/blueprints/editor/draggable-items.directive.js
+++ b/client/app/states/designer/blueprints/editor/draggable-items.directive.js
@@ -27,7 +27,9 @@
       var vm = this;  // jshint ignore:line
 
       vm.clickCallbackfmDir = function(item) {
-        vm.clickCallback(item);
+        if (!item.disableInToolbox) {
+          vm.clickCallback(item);
+        }
       };
 
       vm.startDragCallbackfmDir = function(event, ui, item) {

--- a/client/app/states/designer/blueprints/editor/draggable-items.directive.js
+++ b/client/app/states/designer/blueprints/editor/draggable-items.directive.js
@@ -12,6 +12,7 @@
         items: '=',
         startDragCallback: '=',
         clickCallback: '=',
+        searchText: '='
       },
       controller: draggableItemsController,
       templateUrl: 'app/states/designer/blueprints/editor/draggable-items.html',

--- a/client/app/states/designer/blueprints/editor/draggable-items.html
+++ b/client/app/states/designer/blueprints/editor/draggable-items.html
@@ -1,10 +1,10 @@
 <ul class="catalog-items-list">
-    <li class="catalog-item" ng-repeat="item in vm.items | filter:searchText"
+    <li class="catalog-item" ng-repeat="item in vm.items | filter:vm.searchText"
         data-drag="true" jqyoui-draggable="{onStart:'vm.startDragCallbackfmDir(item)'}"
         data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
         ng-click="vm.clickCallbackfmDir(item)">
         <img ng-if="item.image" src="{{item.image}}">
-        <i ng-if="item.bundle && !item.image" class="fa fa-gift"></i>
+        <i ng-if="item.icon && !item.image" class="draggable-item-icon {{item.icon}}"></i>
         <span>{{ item.name }}</span>
     </li>
 </ul>

--- a/client/app/states/designer/blueprints/editor/draggable-items.html
+++ b/client/app/states/designer/blueprints/editor/draggable-items.html
@@ -1,8 +1,10 @@
 <ul class="catalog-items-list">
     <li class="catalog-item" ng-repeat="item in vm.items | filter:vm.searchText"
-        data-drag="true" jqyoui-draggable="{onStart:'vm.startDragCallbackfmDir(item)'}"
+        data-drag="{{!item.disableInToolbox}}" jqyoui-draggable="{onStart:'vm.startDragCallbackfmDir(item)'}"
+        ng-class="{'not-draggable': item.disableInToolbox}"
         data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
-        ng-click="vm.clickCallbackfmDir(item)">
+        ng-click="vm.clickCallbackfmDir(item)"
+        tooltip="{{(item.disableInToolbox ? 'Items cannot be added to the canvas more than once.' : '') | translate}}">
         <img ng-if="item.image" src="{{item.image}}">
         <i ng-if="item.icon && !item.image" class="draggable-item-icon {{item.icon}}"></i>
         <span>{{ item.name }}</span>

--- a/client/app/states/designer/blueprints/editor/editor.html
+++ b/client/app/states/designer/blueprints/editor/editor.html
@@ -66,7 +66,8 @@
                                   <tab ng-repeat="subsubtab in subtab.subtabs" heading="{{subsubtab.title}}" active="subsubtab.active" ng-click="tabClicked()">
                                       <draggable-items items="subsubtab.items"
                                                        start-drag-callback="startCallback"
-                                                       click-callback="addNodeByClick"/>
+                                                       click-callback="addNodeByClick"
+                                                       search-text="searchText"/>
                                   </tab>
                               </tabset>
 
@@ -74,20 +75,22 @@
                               <draggable-items ng-if="!subtab.subtabs"
                                                items="subtab.items"
                                                start-drag-callback="startCallback"
-                                               click-callback="addNodeByClick"/>
+                                               click-callback="addNodeByClick"
+                                               search-text="searchText"/>
                           </tab>
                       </tabset>
 
                       <!-- Primary Tabs without SubTabs (Bundles) -->
                       <draggable-items ng-if="!tab.subtabs" items="tab.items"
                           start-drag-callback="startCallback"
-                          click-callback="addNodeByClick"/>
+                          click-callback="addNodeByClick"
+                          search-text="searchText"/>
                   </tab>
               </tabset>
 
               <div class="toolbox-footer">
                   <!-- Create New Item -->
-                  <div class="new-catalog-item"
+                  <div class="new-catalog-item" ng-if="getNewItem()"
                        data-drag="true" jqyoui-draggable="{onStart:'startCallback( getNewItem() )'}"
                        data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
                        ng-click="addNodeByClick( getNewItem() )">

--- a/client/app/states/designer/blueprints/editor/editor.state.js
+++ b/client/app/states/designer/blueprints/editor/editor.state.js
@@ -76,10 +76,10 @@
       vm.serviceTemplates = serviceTemplates.resources;
     }
 
-    if (vm.blueprint && vm.blueprint.content && blueprint.content.service_templates && vm.blueprint.ui_properties
+    if (vm.blueprint && vm.serviceTemplates && vm.blueprint.ui_properties
         && vm.blueprint.ui_properties.chart_data_model && vm.blueprint.ui_properties.chart_data_model.nodes
         && vm.blueprint.ui_properties.chart_data_model.nodes.length > 0) {
-      updateCanvasServiceTemplateNodes(vm.blueprint.content.service_templates, vm.blueprint.ui_properties.chart_data_model.nodes);
+      updateCanvasServiceTemplateNodes(vm.serviceTemplates, vm.blueprint.ui_properties.chart_data_model.nodes);
     }
 
     function updateCanvasServiceTemplateNodes(serviceTemplates, nodes) {

--- a/client/app/states/designer/blueprints/editor/editor.state.js
+++ b/client/app/states/designer/blueprints/editor/editor.state.js
@@ -97,6 +97,9 @@
             } else {
               node.image = null;
             }
+            // This service template is already on the canvas
+            // disable it in toolbox
+            srvTemplate.disableInToolbox = true;
             foundNodesSrvTemplate = true;
             break;
           }

--- a/client/app/states/designer/blueprints/editor/editor.state.js
+++ b/client/app/states/designer/blueprints/editor/editor.state.js
@@ -63,7 +63,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, $stateParams, blueprint, blueprintTags, serviceTemplates) {
+  function StateController($log, blueprint, blueprintTags, serviceTemplates) {
     var vm = this;
     vm.title = 'Blueprint Designer';
     if (blueprint) {
@@ -105,7 +105,7 @@
           }
         }
         if (!foundNodesSrvTemplate) {
-          console.log("Cound Not Find Service Template for Canvas Node: " + node.name + "(" + node.id + ")");
+          $log.error("Cound Not Find Service Template for Canvas Node: " + node.name + "(" + node.id + ")");
         }
       }
     }

--- a/client/app/states/designer/blueprints/editor/editorCtrl.js
+++ b/client/app/states/designer/blueprints/editor/editorCtrl.js
@@ -175,7 +175,7 @@
         return activeTab.newItem;
       }
 
-      return {name: 'New Item', image: 'images/service.png'};
+      return null;
     };
 
     $scope.activeTab = function() {

--- a/client/app/states/designer/blueprints/editor/editorCtrl.js
+++ b/client/app/states/designer/blueprints/editor/editorCtrl.js
@@ -31,7 +31,7 @@
 
     BlueprintsState.saveOriginalBlueprint(angular.copy($scope.blueprint));
 
-    // console.log("RETRIEVED Blueprint: " + angular.toJson($scope.blueprint, true));
+    // $log.debug("RETRIEVED Blueprint: " + angular.toJson($scope.blueprint, true));
 
     $scope.$watch("blueprint", function(oldValue, newValue) {
       if (!angular.equals(oldValue, newValue, true)) {
@@ -73,7 +73,7 @@
          BlueprintsState.saveOriginalBlueprint(angular.copy($scope.blueprint));
          blueprintDirty = false;
          $( "#saveBtm" ).blur();
-         console.log("Saved blueprint from designer"); */
+         $log.debug("Saved blueprint from designer"); */
       }
 
       function saveFailure() {

--- a/client/app/states/designer/blueprints/editor/editorCtrl.js
+++ b/client/app/states/designer/blueprints/editor/editorCtrl.js
@@ -3,11 +3,11 @@
 
   angular.module('app.states')
     .controller('BlueprintEditorController', ['$scope', '$timeout', 'BlueprintsState', 'DesignerState', 'BlueprintDetailsModal',
-      'SaveBlueprintModal', '$state', 'Notifications', 'sprintf', ComponentController]);
+      'SaveBlueprintModal', '$state', 'EventNotifications', 'sprintf', ComponentController]);
 
   /** @ngInject */
   function ComponentController($scope, $timeout, BlueprintsState, DesignerState, BlueprintDetailsModal, SaveBlueprintModal, $state,
-                               Notifications, sprintf) {
+                               EventNotifications, sprintf) {
     $scope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) {
       if (toState.name === 'login') {
         return;
@@ -61,7 +61,7 @@
       BlueprintsState.saveBlueprint($scope.blueprint).then(saveSuccess, saveFailure);
 
       function saveSuccess(id) {
-        Notifications.success(sprintf(__("'%s' was succesfully saved."), $scope.blueprint.name));
+        EventNotifications.success(sprintf(__("'%s' was succesfully saved."), $scope.blueprint.name));
         if (id) {
           $state.go($state.current, {blueprintId: id}, {reload: true});
         }
@@ -77,7 +77,7 @@
       }
 
       function saveFailure() {
-        Notifications.error(sprintf(__("Failed to save '%s'."), $scope.blueprint.name));
+        EventNotifications.error(sprintf(__("Failed to save '%s'."), $scope.blueprint.name));
       }
     };
 

--- a/client/app/states/designer/blueprints/editor/save-blueprint-modal-service.factory.js
+++ b/client/app/states/designer/blueprints/editor/save-blueprint-modal-service.factory.js
@@ -32,7 +32,8 @@
   }
 
   /** @ngInject */
-  function SaveBlueprintModalController(blueprint, toState, toParams, fromState, fromParams, $state, $modalInstance, BlueprintsState) {
+  function SaveBlueprintModalController(blueprint, toState, toParams, fromState, fromParams, $state, $modalInstance, $log,
+                                        BlueprintsState) {
     var vm = this;
     vm.blueprint = blueprint;
     vm.save = save;
@@ -49,7 +50,7 @@
       }
 
       function saveFailure() {
-        console.log("Failed to nav away and save blueprint.");
+        $log.error("Failed to nav away and save blueprint.");
         $modalInstance.close();
       }
     }


### PR DESCRIPTION
**Updated Toolbox Tabs and correct placement of existing service templates under Tabs:**

![image](https://cloud.githubusercontent.com/assets/12733153/18712873/5b470ca6-7fde-11e6-82f4-df9c313b9521.png)

**Toolbox Items can only be added to canvas once:**

![image](https://cloud.githubusercontent.com/assets/12733153/18712902/77e1ba50-7fde-11e6-9ac6-4358b4fafbf7.png)

**Misc. Fixes/Updates:**
- Using new PF Bundle Icon
- Fixed NodeToolbar in FireFox
- Fixed Toolbox Search Filter
- Fixed updating canvas node's name and img to match 'parent' service template changes
- Replaced all console.log's with $log
- Fixed Save Blueprint notification

**Related JIRA stories:**

[CFUX-12 - SSUI 4.2: Need to Categorize Service Templates under Toolbox Tabs](https://patternfly.atlassian.net/browse/CFUX-12)
[CFUX-13 - SSUI 4.2: Items in the toolbox can only be added to the blueprint once - Dev](https://patternfly.atlassian.net/browse/CFUX-13)

@serenamarie125 @chriskacerguis @jeff-phillips-18 