### PR TITLE
engines category required for eslint to work in code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,6 @@
-eslint:
-  enabled: true
-  channel: "eslint-3"
-  config:
-    config: .eslintrc.json
+engines:
+  eslint:
+    enabled: true
+    channel: "eslint-3"
+    config:
+      config: .eslintrc.json


### PR DESCRIPTION
Codeclimate will now function as expected with regards to running eslint