### PR TITLE
Refactor/eslint consistent this

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,7 +63,7 @@
     "consistent-return": "off",
     "consistent-this": [
       "error",
-      "this"
+      "vm"
     ],
     "curly": "error",
     "default-case": "off",
@@ -226,6 +226,7 @@
     "no-unneeded-ternary": "error",
     "no-unsafe-negation": "error",
     "no-unused-expressions": "off",
+    "no-unused-vars": "off",
     "no-use-before-define": "off",
     "no-useless-call": "error",
     "no-useless-computed-key": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,7 +63,7 @@
     "consistent-return": "off",
     "consistent-this": [
       "error",
-      "vm"
+      "this"
     ],
     "curly": "error",
     "default-case": "off",
@@ -226,7 +226,6 @@
     "no-unneeded-ternary": "error",
     "no-unsafe-negation": "error",
     "no-unused-expressions": "off",
-    "no-unused-vars": "off",
     "no-use-before-define": "off",
     "no-useless-call": "error",
     "no-useless-computed-key": "error",

--- a/client/app/components/blueprint-details-modal/blueprint-order-list.service.js
+++ b/client/app/components/blueprint-details-modal/blueprint-order-list.service.js
@@ -1,4 +1,6 @@
 /* eslint camelcase: "off" */
+/* eslint consistent-this: "off" */
+
 (function() {
   'use strict';
 

--- a/client/app/components/blueprint-details-modal/blueprint-order-list.service.js
+++ b/client/app/components/blueprint-details-modal/blueprint-order-list.service.js
@@ -1,6 +1,4 @@
 /* eslint camelcase: "off" */
-/* eslint consistent-this: "off" */
-
 (function() {
   'use strict';
 

--- a/client/app/components/confirmation/confirmation.directive.js
+++ b/client/app/components/confirmation/confirmation.directive.js
@@ -30,24 +30,24 @@
 
     return directive;
 
-    function link(scope, element, attrs, controller, transclude) {
-      controller.activate({
+    function link(scope, element, attrs, vm, transclude) {
+      vm.activate({
         getOffset: getOffset,
         getPosition: getPosition,
         size: getSizeOfConfirmation(),
       });
 
-      if (angular.isDefined(controller.triggerOnValue)) {
+      if (angular.isDefined(vm.triggerOnValue)) {
         scope.$watch(function() {
-          return controller.triggerOnValue;
+          return vm.triggerOnValue;
         },
         function(newValue) {
           if (newValue === true) {
-            controller.onTrigger();
+            vm.onTrigger();
           }
         });
       } else {
-        element.on(attrs.confirmationTrigger || 'click', controller.onTrigger);
+        element.on(attrs.confirmationTrigger || 'click', vm.onTrigger);
       }
 
       function getOffset() {

--- a/client/app/components/confirmation/confirmation.directive.js
+++ b/client/app/components/confirmation/confirmation.directive.js
@@ -30,24 +30,24 @@
 
     return directive;
 
-    function link(scope, element, attrs, vm, transclude) {
-      vm.activate({
+    function link(scope, element, attrs, controller, transclude) {
+      controller.activate({
         getOffset: getOffset,
         getPosition: getPosition,
         size: getSizeOfConfirmation(),
       });
 
-      if (angular.isDefined(vm.triggerOnValue)) {
+      if (angular.isDefined(controller.triggerOnValue)) {
         scope.$watch(function() {
-          return vm.triggerOnValue;
+          return controller.triggerOnValue;
         },
         function(newValue) {
           if (newValue === true) {
-            vm.onTrigger();
+            controller.onTrigger();
           }
         });
       } else {
-        element.on(attrs.confirmationTrigger || 'click', vm.onTrigger);
+        element.on(attrs.confirmationTrigger || 'click', controller.onTrigger);
       }
 
       function getOffset() {

--- a/client/app/components/custom-button/custom-button.directive.js
+++ b/client/app/components/custom-button/custom-button.directive.js
@@ -24,11 +24,11 @@
 
     return directive;
 
-    function link(scope, element, attrs, vm, transclude) {
-      vm.activate();
+    function link(scope, element, attrs, controller, transclude) {
+      controller.activate();
 
       var win = angular.element($window);
-      win.bind('resize', function() { 
+      win.bind('resize', function() {
         scope.$apply();
       });
 
@@ -43,14 +43,14 @@
 
       function checkRoomForButtons() {
         // Allow the buttons to render to calculate width
-        vm.collapseCustomButtons = false;
+        controller.collapseCustomButtons = false;
 
         $timeout(function() {
           var outerWidth = document.querySelectorAll('.ss-details-header__actions')[0].offsetWidth;
           var innerWidth = document.querySelectorAll('.ss-details-header__actions__inner')[0].offsetWidth;
           if (innerWidth >= outerWidth) {
             // Not enough room - collapse them down
-            vm.collapseCustomButtons = true;
+            controller.collapseCustomButtons = true;
           }
         }, 0);
       }

--- a/client/app/components/custom-button/custom-button.directive.js
+++ b/client/app/components/custom-button/custom-button.directive.js
@@ -24,11 +24,11 @@
 
     return directive;
 
-    function link(scope, element, attrs, controller, transclude) {
-      controller.activate();
+    function link(scope, element, attrs, vm, transclude) {
+      vm.activate();
 
       var win = angular.element($window);
-      win.bind('resize', function() {
+      win.bind('resize', function() { 
         scope.$apply();
       });
 
@@ -43,14 +43,14 @@
 
       function checkRoomForButtons() {
         // Allow the buttons to render to calculate width
-        controller.collapseCustomButtons = false;
+        vm.collapseCustomButtons = false;
 
         $timeout(function() {
           var outerWidth = document.querySelectorAll('.ss-details-header__actions')[0].offsetWidth;
           var innerWidth = document.querySelectorAll('.ss-details-header__actions__inner')[0].offsetWidth;
           if (innerWidth >= outerWidth) {
             // Not enough room - collapse them down
-            controller.collapseCustomButtons = true;
+            vm.collapseCustomButtons = true;
           }
         }, 0);
       }

--- a/client/app/components/dialog-content/dialog-content.directive.js
+++ b/client/app/components/dialog-content/dialog-content.directive.js
@@ -23,8 +23,8 @@
 
     return directive;
 
-    function link(scope, element, attrs, vm, transclude) {
-      vm.activate();
+    function link(scope, element, attrs, controller, transclude) {
+      controller.activate();
     }
 
     /** @ngInject */

--- a/client/app/components/footer/footer-content.directive.js
+++ b/client/app/components/footer/footer-content.directive.js
@@ -19,8 +19,8 @@
 
     return directive;
 
-    function link(scope, element, attrs, vm, transclude) {
-      vm.activate();
+    function link(scope, element, attrs, controller, transclude) {
+      controller.activate();
     }
 
     /** @ngInject */

--- a/client/app/components/footer/footer-content.directive.js
+++ b/client/app/components/footer/footer-content.directive.js
@@ -19,8 +19,8 @@
 
     return directive;
 
-    function link(scope, element, attrs, controller, transclude) {
-      controller.activate();
+    function link(scope, element, attrs, vm, transclude) {
+      vm.activate();
     }
 
     /** @ngInject */

--- a/client/app/components/shopping-cart/shopping-cart.directive.js
+++ b/client/app/components/shopping-cart/shopping-cart.directive.js
@@ -20,8 +20,8 @@
 
     return directive;
 
-    function link(scope, element, attrs, controller, transclude) {
-      controller.activate();
+    function link(scope, element, attrs, vm, transclude) {
+      vm.activate();
     }
 
     /** @ngInject */

--- a/client/app/components/shopping-cart/shopping-cart.directive.js
+++ b/client/app/components/shopping-cart/shopping-cart.directive.js
@@ -20,8 +20,8 @@
 
     return directive;
 
-    function link(scope, element, attrs, vm, transclude) {
-      vm.activate();
+    function link(scope, element, attrs, controller, transclude) {
+      controller.activate();
     }
 
     /** @ngInject */

--- a/client/app/components/ss-card/ss-card.directive.js
+++ b/client/app/components/ss-card/ss-card.directive.js
@@ -24,8 +24,8 @@
 
     return directive;
 
-    function link(scope, element, attrs, controller, transclude) {
-      controller.activate();
+    function link(scope, element, attrs, vm, transclude) {
+      vm.activate();
     }
 
     /** @ngInject */

--- a/client/app/components/ss-card/ss-card.directive.js
+++ b/client/app/components/ss-card/ss-card.directive.js
@@ -24,8 +24,8 @@
 
     return directive;
 
-    function link(scope, element, attrs, vm, transclude) {
-      vm.activate();
+    function link(scope, element, attrs, controller, transclude) {
+      controller.activate();
     }
 
     /** @ngInject */

--- a/client/app/components/tagging/tagging.directive.js
+++ b/client/app/components/tagging/tagging.directive.js
@@ -117,7 +117,7 @@
           attributes: attributes,
         };
 
-        var collection = vm.objectType + '\/' + vm.objectId + '\/ tags';
+        var collection = vm.objectType + '/' + vm.objectId + '/tags';
 
         CollectionsApi.query(collection, options).then(loadSuccess, loadFailure);
 

--- a/client/app/services/blueprints-state.service.js
+++ b/client/app/services/blueprints-state.service.js
@@ -227,7 +227,7 @@
       var assignObj = getTagsToAddRemove("assign", blueprintTags, origBlueprintTags);
       var unassignObj = getTagsToAddRemove("unassign", blueprintTags, origBlueprintTags);
 
-      var collection = 'blueprints \/' + blueprintId + '\/ tags';
+      var collection = 'blueprints/' + blueprintId + '/tags';
 
       if (assignObj.resources.length > 0) {
         CollectionsApi.post(collection, null, {}, assignObj).then(function() {
@@ -306,7 +306,7 @@
       var assignObj = getTagsToAddRemove("assign", tags, origTags);
       var unassignObj = getTagsToAddRemove("unassign", tags, origTags);
 
-      var collection = 'service_templates \/' + id + '\/ tags';
+      var collection = 'service_templates/' + id + '/tags';
 
       if (assignObj.resources.length > 0) {
         CollectionsApi.post(collection, null, {}, assignObj).then(function() {

--- a/client/app/states/administration/profiles/details/details.state.js
+++ b/client/app/states/administration/profiles/details/details.state.js
@@ -45,7 +45,7 @@
       $state.go('administration.profiles.editor', {profileId: vm.profile.id});
     }
 
-    function setInitialVars(vm) {
+    function setInitialVars() {
       vm.profile = profile;
       vm.profile.providerType = ProfilesState.getProviderType(vm.profile.ext_management_system);
       vm.profile.providerImage = ProfilesState.getProviderTypeImage(vm.profile.ext_management_system);
@@ -54,7 +54,7 @@
       vm.editProfile = editProfile;
     }
 
-    setInitialVars(vm);
+    setInitialVars();
 
     activate();
 

--- a/client/app/states/administration/profiles/details/details.state.js
+++ b/client/app/states/administration/profiles/details/details.state.js
@@ -45,7 +45,7 @@
       $state.go('administration.profiles.editor', {profileId: vm.profile.id});
     }
 
-    function setInitialVars() {
+    function setInitialVars(vm) {
       vm.profile = profile;
       vm.profile.providerType = ProfilesState.getProviderType(vm.profile.ext_management_system);
       vm.profile.providerImage = ProfilesState.getProviderTypeImage(vm.profile.ext_management_system);
@@ -54,7 +54,7 @@
       vm.editProfile = editProfile;
     }
 
-    setInitialVars();
+    setInitialVars(vm);
 
     activate();
 

--- a/client/app/states/administration/profiles/editor/editor.state.js
+++ b/client/app/states/administration/profiles/editor/editor.state.js
@@ -219,7 +219,7 @@
       }
     }
 
-    function setInitialVars() {
+    function setInitialVars(vm) {
       vm.profile = profile;
       vm.editInfo = {};
 
@@ -269,7 +269,7 @@
       updateSelections();
     }
 
-    setInitialVars();
+    setInitialVars(vm);
 
     activate();
 

--- a/client/app/states/administration/profiles/editor/editor.state.js
+++ b/client/app/states/administration/profiles/editor/editor.state.js
@@ -219,7 +219,7 @@
       }
     }
 
-    function setInitialVars(vm) {
+    function setInitialVars() {
       vm.profile = profile;
       vm.editInfo = {};
 
@@ -269,7 +269,7 @@
       updateSelections();
     }
 
-    setInitialVars(vm);
+    setInitialVars();
 
     activate();
 

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -127,14 +127,6 @@
     return CollectionsApi.query('services', options);
   }
 
-  function resolveRequestPromises(promiseArray, vm, type, lodash, $q) {
-    $q.all(promiseArray).then(function(data) {
-      var count = lodash.sum(data, 'subcount');
-      vm.requestsCount[type] = count;
-      vm.requestsCount.total += count;
-    });
-  }
-
   /** @ngInject */
   function StateController($state, RequestsState, ServicesState, definedServiceIdsServices, retiredServices,
     expiringServices, allRequests, lodash, $q) {
@@ -169,7 +161,7 @@
       var allRequestTypes = ['pending', 'approved', 'denied'];
 
       allRequests.forEach(function(promise, n) {
-        resolveRequestPromises(promise, vm, allRequestTypes[n], lodash, $q);
+        resolveRequestPromises(promise, allRequestTypes[n], lodash, $q);
       });
 
       vm.requestsFeature = true;
@@ -186,5 +178,13 @@
       ServicesState.filterApplied = true;
       $state.go('services.list');
     };
+
+    function resolveRequestPromises(promiseArray, type, lodash, $q) {
+      $q.all(promiseArray).then(function(data) {
+        var count = lodash.sum(data, 'subcount');
+        vm.requestsCount[type] = count;
+        vm.requestsCount.total += count;
+      });
+    }
   }
 })();

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -127,6 +127,14 @@
     return CollectionsApi.query('services', options);
   }
 
+  function resolveRequestPromises(promiseArray, vm, type, lodash, $q) {
+    $q.all(promiseArray).then(function(data) {
+      var count = lodash.sum(data, 'subcount');
+      vm.requestsCount[type] = count;
+      vm.requestsCount.total += count;
+    });
+  }
+
   /** @ngInject */
   function StateController($state, RequestsState, ServicesState, definedServiceIdsServices, retiredServices,
     expiringServices, allRequests, lodash, $q) {
@@ -161,7 +169,7 @@
       var allRequestTypes = ['pending', 'approved', 'denied'];
 
       allRequests.forEach(function(promise, n) {
-        resolveRequestPromises(promise, allRequestTypes[n], lodash, $q);
+        resolveRequestPromises(promise, vm, allRequestTypes[n], lodash, $q);
       });
 
       vm.requestsFeature = true;
@@ -178,13 +186,5 @@
       ServicesState.filterApplied = true;
       $state.go('services.list');
     };
-
-    function resolveRequestPromises(promiseArray, type, lodash, $q) {
-      $q.all(promiseArray).then(function(data) {
-        var count = lodash.sum(data, 'subcount');
-        vm.requestsCount[type] = count;
-        vm.requestsCount.total += count;
-      });
-    }
   }
 })();

--- a/client/app/states/designer/blueprints/editor/editor.state.js
+++ b/client/app/states/designer/blueprints/editor/editor.state.js
@@ -42,7 +42,7 @@
         expand: 'resources',
         attributes: attributes,
       };
-      var collection = 'blueprints \/' + $stateParams.blueprintId + '\/ tags';
+      var collection = 'blueprints/' + $stateParams.blueprintId + '/tags';
 
       return CollectionsApi.query(collection, options);
     } else {

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -54,7 +54,7 @@
   /** @ngInject */
   function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, EventNotifications, Consoles) {
     var vm = this;
-    setInitialVars(vm);
+    setInitialVars();
 
     if (angular.isUndefined(vm.service.vms)) {
       vm.vms = [];
@@ -86,7 +86,7 @@
     function activate() {
     }
 
-    function setInitialVars(vm) {
+    function setInitialVars() {
       vm.showRemoveService = $state.actionFeatures.serviceDelete.show;
       vm.showRetireService = $state.actionFeatures.serviceRetireNow.show;
       vm.showScheduleRetirementService = $state.actionFeatures.serviceRetire.show;

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -54,7 +54,7 @@
   /** @ngInject */
   function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, EventNotifications, Consoles) {
     var vm = this;
-    setInitialVars();
+    setInitialVars(vm);
 
     if (angular.isUndefined(vm.service.vms)) {
       vm.vms = [];
@@ -86,7 +86,7 @@
     function activate() {
     }
 
-    function setInitialVars() {
+    function setInitialVars(vm) {
       vm.showRemoveService = $state.actionFeatures.serviceDelete.show;
       vm.showRetireService = $state.actionFeatures.serviceRetireNow.show;
       vm.showScheduleRetirementService = $state.actionFeatures.serviceRetire.show;


### PR DESCRIPTION
Resolves: 
- no-unsed-var
- consistent-this

This pr resolves the issue of viewing existing blueprints.
This pr removes the no-unused-variables constraint from functions (the remaining offenders) 
This pr does away with vm in directive link functions (for angular recommended `controller` naming).  You'll notice in dashboard state the resolution function was brought into the controller function, this state needs to be overhauled to take advantage of ui-router state resolve (seen [here](https://github.com/angular-ui/ui-router/wiki#resolve))

Please excuse the revert and the revert of the revert, sure i coulda squashed the commit but.... 

## Before
<img width="556" alt="screen shot 2016-09-22 at 2 32 50 pm" src="https://cloud.githubusercontent.com/assets/6640236/18761081/92dc1a14-80d1-11e6-80b2-ddad768523f6.png">

## After
<img width="486" alt="screen shot 2016-09-22 at 2 31 18 pm" src="https://cloud.githubusercontent.com/assets/6640236/18761082/92e0eee0-80d1-11e6-9139-bd741608ff01.png">

shout out to @dtaylor113 and @chriskacerguis for 👀 

#121 almost done
