### PR TITLE
Translation fixes

### DIFF
--- a/client/app/components/blueprint-details-modal/blueprint-details-modal.html
+++ b/client/app/components/blueprint-details-modal/blueprint-details-modal.html
@@ -132,7 +132,7 @@
             </div>
         </tab>
         <tab active="vm.tabs[3].active" heading="{{vm.tabs[3].title}}"  disable="vm.disableOrderListTabs()">
-            <h4 translate>Rearrange Items to set Action Order
+            <h4>{{ 'Rearrange Items to set Action Order' | translate}}
                 <input class="actionOrderCheckbox"
                        ng-model="vm.actionOrderEqualsProvOrder"
                        ng-change="vm.toggleActionEqualsProvOrder()"

--- a/client/app/components/blueprint-details-modal/blueprint-details-modal.html
+++ b/client/app/components/blueprint-details-modal/blueprint-details-modal.html
@@ -72,8 +72,7 @@
                     </div>
                 </div>
             </form>
-            <a id="advOpsHref" ng-click="vm.toggleAdvOps()" data-toggle="collapse" class="collapsed" translate>Advanced
-                Options</a>
+            <a id="advOpsHref" ng-click="vm.toggleAdvOps()" data-toggle="collapse" class="collapsed" translate>Advanced Options</a>
 
             <div id="advOps" class="collapse">
                 <form novalidate name="advOptsForm" id="advOptsForm" class="form-horizontal">

--- a/client/app/states/administration/profiles/profiles.html
+++ b/client/app/states/administration/profiles/profiles.html
@@ -21,7 +21,7 @@
        confirmation-on-ok="vm.removeProfile(item)"
        confirmation-on-cancel="vm.cancelRemoveProfile(item)"
        confirmation-ok-style="primary"
-       confirmation-show-cancel="true" translate>
+       confirmation-show-cancel="true">
     <div pf-list-view id="arbitrationProfilesList" class="arbitration-profiles-list" config="vm.listConfig" items="vm.arbitrationProfilesList"
          action-buttons="vm.actionButtons"
          menu-actions="vm.menuActions">

--- a/client/app/states/administration/rules/rules.html
+++ b/client/app/states/administration/rules/rules.html
@@ -133,7 +133,7 @@
                           confirmation-ok-text="{{'Delete'|translate}}"
                           confirmation-on-ok="vm.removeRule(item)"
                           confirmation-ok-style="primary"
-                          confirmation-show-cancel="true" translate>
+                          confirmation-show-cancel="true">
                     <span class="pficon pficon-delete"></span>
                   </button>
                 </div>

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -29,7 +29,7 @@
        <div class="col-lg-2 col-md-2 hidden-sm hidden-xs">
         <span class="no-wrap">
            <i class="pficon pficon-screen" tooltip="{{'The number of instances running this service'|translate}}" tooltip-placement="bottom"></i>
-          <span translate tooltip="{{item.v_total_vms}} VMs" tooltip-placement="bottom">
+          <span tooltip="{{item.v_total_vms}} VMs" tooltip-placement="bottom">
             <strong>{{ item.v_total_vms}}</strong>
             {{'VMs'|translate}}
           </span>


### PR DESCRIPTION
These are fixes to make sure:
* the strings to translate do not contain html markup
* the string to translate do not contain unnecessary newlines

@himdel Please review

@chriskacerguis These are things that need to be caught at a PR review.