### PR TITLE
Add substitute filter

### DIFF
--- a/client/app/components/notifications/notification-footer.html
+++ b/client/app/components/notifications/notification-footer.html
@@ -11,8 +11,8 @@
        ng-class="{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}"
        confirmation
        confirmation-if="true"
-       confirmation-title="{{'Clear All ' + notificationGroup.heading |translate}}"
-       confirmation-message="{{'Are you sure you would like to clear all ' + notificationGroup.heading + '?'|translate}}"
+       confirmation-title="{{'Clear All [[heading]]'|translate|substitute:{heading: notificationGroup.heading}}}"
+       confirmation-message="{{'Are you sure you would like to clear all [[heading]]?'|translate|substitute:{heading: notificationGroup.heading}}}"
        confirmation-ok-text="{{'Clear All'|translate}}"
        confirmation-on-ok="customScope.clearAllNotifications(notificationGroup)"
        confirmation-ok-style="primary"

--- a/client/app/filters/substitute.js
+++ b/client/app/filters/substitute.js
@@ -1,0 +1,12 @@
+(function() {
+  'use strict';
+
+  angular.module('app.services').filter('substitute', function($interpolate) {
+    return function(text, context) {
+      text = text.replace(/\[\[/g, '{{').replace(/\]\]/g, '}}');
+      var interpolateFn = $interpolate(text);
+
+      return interpolateFn(context);
+    };
+  });
+})();

--- a/client/app/states/administration/profiles/profiles.html
+++ b/client/app/states/administration/profiles/profiles.html
@@ -14,9 +14,7 @@
        confirmation-if="true"
        confirmation-trigger-value="vm.confirmDelete"
        confirmation-title="{{'Delete Profile'|translate}}"
-       confirmation-message="{{'Are you sure you want to delete profile ' +
-                               (vm.profileToDelete ? vm.profileToDelete.name : '') +
-                               '?'|translate}}"
+       confirmation-message="{{'Are you sure you want to delete profile [[profile_name]]?'|translate|substitute:{profile_name: vm.profileToDelete ? vm.profileToDelete.name : ''} }}"
        confirmation-ok-text="{{'Delete'|translate}}"
        confirmation-on-ok="vm.removeProfile(item)"
        confirmation-on-cancel="vm.cancelRemoveProfile(item)"

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -29,7 +29,7 @@
        <div class="col-lg-2 col-md-2 hidden-sm hidden-xs">
         <span class="no-wrap">
            <i class="pficon pficon-screen" tooltip="{{'The number of instances running this service'|translate}}" tooltip-placement="bottom"></i>
-          <span tooltip="{{item.v_total_vms}} VMs" tooltip-placement="bottom">
+          <span tooltip="{{ '[[number]] VMs'|translate|substitute:{number: item.v_total_vms} }}" tooltip-placement="bottom">
             <strong>{{ item.v_total_vms}}</strong>
             {{'VMs'|translate}}
           </span>

--- a/client/index.html
+++ b/client/index.html
@@ -165,6 +165,7 @@
   <script src="/client/app/core/config.js"></script>
   <script src="/client/app/core/constants.js"></script>
   <script src="/client/app/filters/format-bytes.filter.js"></script>
+  <script src="/client/app/filters/substitute.js"></script>
   <script src="/client/app/resources/authentication-api.factory.js"></script>
   <script src="/client/app/resources/collections-api.factory.js"></script>
   <script src="/client/app/services/blueprints-state.service.js"></script>


### PR DESCRIPTION
In certain situations, it's not possible to correctly annotate strings for translation when these
strings are a value of an html element and contain a variable interpolation. For example:

```html
<span tooltip="{{item.v_total_vms}} VMs">
```

This is where the `substitute` filter comes in handy. The above situation would then be resolved as:

```html
<span tooltip="{{ '[[number]] VMs'|translate|substitute:{number: item.v_total_vms} }}">
```
i.e. `[[` and `]]` mark start and end of a variable to be substituted, the actual values would be
then substituted with the context of the `substitute` filter.

With the substitute filter, the string with interpolation contained in an element attribute can:
* be properly substituted
* be properly marked for translation

The pull request also fixes the above problem in couple of html files.