### PR TITLE
Designer: Fixed text wrapping of node titles

### DIFF
--- a/client/app/components/flowchart/_flowchart.sass
+++ b/client/app/components/flowchart/_flowchart.sass
@@ -1,5 +1,11 @@
 .node-header
-  font-size: 12px
+  display: table
+  font-weight: 600
+
+  p
+    display: table-cell
+    text-align: center
+    vertical-align: middle
 
 .invalid-node-header
   fill: #bababa

--- a/client/app/components/flowchart/flowchart_directive.js
+++ b/client/app/components/flowchart/flowchart_directive.js
@@ -82,7 +82,7 @@ angular.module('flowChart', ['dragging'] )
 // it is painful to unit test a directive without instantiating the DOM
 // (which is possible, just not ideal).
 //
-.controller('FlowChartController', ['$scope', 'dragging', '$element', function FlowChartController($scope, dragging, $element) {
+.controller('FlowChartController', ['$scope', 'dragging', '$element', '$document', function FlowChartController($scope, dragging, $element, $document) {
   var controller = this;// jscs:ignore safeContextKeyword
 
   //
@@ -160,6 +160,14 @@ angular.module('flowChart', ['dragging'] )
 
   $scope.availableConnections = function() {
     return $scope.chart.validConnections;
+  };
+
+  $scope.foreignObjectSupported = function() {
+    if ($document[0].implementation.hasFeature('http://www.w3.org/TR/SVG11/feature#Extensibility', '1.1')) {
+      return true;
+    } else {
+      return false;
+    }
   };
 
   //

--- a/client/app/components/flowchart/flowchart_template.html
+++ b/client/app/components/flowchart/flowchart_template.html
@@ -39,7 +39,7 @@
       />
 
     <!-- Node Title -->
-    <text
+    <text ng-if="!foreignObjectSupported()"
       class="node-header"
       ng-class="{'invalid-node-header': node.invalid()}"
       ng-attr-x="{{node.width()/2}}"
@@ -49,6 +49,20 @@
       >
       {{node.name()}}
     </text>
+
+    <foreignObject ng-if="foreignObjectSupported()"
+                   x="0"
+                   ng-attr-y="{{node.height() - 42}}"
+                   ng-attr-width="{{node.width()}}"
+                   ng-attr-height="{{node.height() - 42}}">
+      <body>
+        <div class="node-header"
+             ng-attr-width="{{node.width()}}"
+             ng-attr-height="{{node.height() - 42}}">
+          <p ng-style="{width: node.width()}">{{node.name()}}</p>
+        </div>
+      </body>
+    </foreignObject>
 
     <!-- Node Image -->
     <image ng-if="node.image()"


### PR DESCRIPTION
This PR finally addresses the wrapping of long node titles (yay!).  Using SVG's `<foreignObject>` which inserts HTML within an SVG.  Using the `<p>` tag and styling to force text wrapping.  This works in Chrome and FireFox:

![image](https://cloud.githubusercontent.com/assets/12733153/18837263/1ee89d8c-83d1-11e6-868d-27b88757a2da.png)

Unfortunately, `<foreignObject>` is not supported in IE 11 or lower, but code exists to render the node titles (without wrapping):

![image](https://cloud.githubusercontent.com/assets/12733153/18837416/b4f486d8-83d1-11e6-9dbb-4e08a17aba40.png)

Browserstack isn't showing the images :-(

@chriskacerguis @serenamarie125 @dgutride 