### PR TITLE
gulp - fix skinning - broken inject

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -61,7 +61,7 @@ module.exports = (function() {
   var serverApp = server + 'app.js';
 
   function getClientJsFiles(ordered, includeSpecs) {
-    var files = [client + 'app/**/*.js', client + 'app/skin/**/*.js'];
+    var files = [client + 'app/**/*.js', client + 'skin/**/*.js'];
 
     if (ordered) {
       files = [].concat(client + 'app/globals.js', client + 'app/app.module.js', client + 'app/**/*module*.js', files)


### PR DESCRIPTION
The changes in 69539c8e (#124) broke the JS part of skinning support - this makes gulp look in `client/skin/` (the directory provided by skins) again.

Cc @AllenBW, @ZitaNemeckova 