### PR TITLE
Fix angular parsing error

### DIFF
--- a/client/app/components/notifications/notification-footer.html
+++ b/client/app/components/notifications/notification-footer.html
@@ -11,8 +11,8 @@
        ng-class="{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}"
        confirmation
        confirmation-if="true"
-       confirmation-title="{{'Clear All [[heading]]'|translate|substitute:{heading: notificationGroup.heading}}}"
-       confirmation-message="{{'Are you sure you would like to clear all [[heading]]?'|translate|substitute:{heading: notificationGroup.heading}}}"
+       confirmation-title="{{'Clear All [[heading]]'|translate|substitute:{heading: notificationGroup.heading} }}"
+       confirmation-message="{{'Are you sure you would like to clear all [[heading]]?'|translate|substitute:{heading: notificationGroup.heading} }}"
        confirmation-ok-text="{{'Clear All'|translate}}"
        confirmation-on-ok="customScope.clearAllNotifications(notificationGroup)"
        confirmation-ok-style="primary"


### PR DESCRIPTION
Object closing curly bracket `}` should not be followed by angular closing brackets `}}`.