### PR TITLE
Add styling to correctly place the main content area for vertical nav

### DIFF
--- a/client/app/layouts/_application.sass
+++ b/client/app/layouts/_application.sass
@@ -39,3 +39,9 @@ body
 .main-content
   overflow-x: hidden
 
+.layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical
+  position: fixed
+  top: 60px
+  left: 0
+  right: 0
+  bottom: 0


### PR DESCRIPTION
Add styles to correctly place the main content area. I was being set too low leaving a top padding before the content.

Before:
![image](https://cloud.githubusercontent.com/assets/11633780/19006749/35389e96-872f-11e6-8a76-e12df03722cd.png)

After:
![image](https://cloud.githubusercontent.com/assets/11633780/19006755/3fb86766-872f-11e6-85d5-c2acfd804373.png)

@serenamarie125 @chriskacerguis @dtaylor113 