### PR TITLE
Fix About Modal and dropdown info for downstream

### DIFF
--- a/client/app/components/navigation/navigation-contoller.js
+++ b/client/app/components/navigation/navigation-contoller.js
@@ -15,6 +15,7 @@
     '$state',
     'EventNotifications',
     'ServerInfo',
+    'ProductInfo',
     NavigationCtrl]);
 
   /** @ngInject */
@@ -28,7 +29,8 @@
                           $modal,
                           $state,
                           EventNotifications,
-                          ServerInfo) {
+                          ServerInfo,
+                          ProductInfo) {
     var vm = this;
     vm.text = Text.app;
     vm.user = Session.currentUser;
@@ -121,7 +123,6 @@
     vm.about = {
       isOpen: false,
       additionalInfo: "",
-      copyright: __("Copyright (c) 2016 ManageIQ. Sponsored by Red Hat Inc."),
       imgAlt: __("Product logo"),
       imgSrc: "images/login-screen-logo.png",
       title: Text.app.name,
@@ -134,6 +135,11 @@
         { name: __('User Name: '), value: ServerInfo.data.user },
         { name: __('User Role: '), value: ServerInfo.data.role },
       ];
+    });
+    ProductInfo.promise.then( function() {
+      vm.about.copyright = ProductInfo.data.copyright;
+      vm.about.supportWebsiteText = ProductInfo.data.supportWebsiteText;
+      vm.about.supportWebsite = ProductInfo.data.supportWebsite;
     });
     vm.openAbout = function() {
       vm.about.isOpen = true;

--- a/client/app/config/authorization.config.js
+++ b/client/app/config/authorization.config.js
@@ -57,7 +57,7 @@
   }
 
   /** @ngInject */
-  function init($rootScope, $state, Session, $sessionStorage, logger, Language, ServerInfo) {
+  function init($rootScope, $state, Session, $sessionStorage, logger, Language, ServerInfo, ProductInfo) {
     var unregisterStart = $rootScope.$on('$stateChangeStart', changeStart);
     var unregisterError = $rootScope.$on('$stateChangeError', changeError);
     var unregisterSuccess = $rootScope.$on('$stateChangeSuccess', changeSuccess);
@@ -91,6 +91,7 @@
       Session.loadUser()
         .then(Language.onReload)
         .then(ServerInfo.set)
+        .then(ProductInfo.set)
         .then(rbacReloadOrLogin(toState, toParams))
         .catch(badUser);
     }

--- a/client/app/layouts/application.html
+++ b/client/app/layouts/application.html
@@ -43,8 +43,8 @@
               </a>
             </li>
             <li>
-              <a href="http://www.manageiq.org" target="_new">
-                ManageIQ.org
+              <a href="{{vm.about.supportWebsite}}" target="_new">
+                {{vm.about.supportWebsiteText}}
               </a>
             </li>
             <li>

--- a/client/app/services/product-info.service.js
+++ b/client/app/services/product-info.service.js
@@ -1,0 +1,26 @@
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('ProductInfo', ProductInfo);
+
+  /** @ngInject */
+  function ProductInfo($q) {
+    var factory = {};
+    factory.data = {};
+    factory.promise = $q(function(resolve) {
+      factory.set = function(data) {
+        factory.data = {
+          copyright: data.product_info.copyright,
+          supportWebsiteText: data.product_info.support_website_text,
+          supportWebsite: data.product_info.support_website,
+        };
+        resolve(factory.data);
+
+        return data;
+      };
+    });
+
+    return factory;
+  }
+})();

--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -26,7 +26,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, Session, $rootScope, Notifications, Language, ServerInfo) {
+  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, Session, $rootScope, Notifications, Language, ServerInfo, ProductInfo) {
     var vm = this;
 
     vm.text = Text.login;
@@ -50,6 +50,7 @@
       return AuthenticationApi.login(vm.credentials.login, vm.credentials.password)
         .then(Session.loadUser)
         .then(ServerInfo.set)
+        .then(ProductInfo.set)
         .then(Language.onLogin)
         .then(function() {
           if (Session.activeNavigationFeatures()) {


### PR DESCRIPTION
The About Modal and dropdown currently displays hard-coded information which works for upstream but is incorrect in a productized environment like downstream.
This PR removes those hard-coded values and instead uses the product info retrieved from the `/api` API.

Notice in the screenshots below that the `Copyright` and `Support Website` values have been fixed.

Before:
<img width="1420" alt="screen shot 2016-09-27 at 3 53 27 pm" src="https://cloud.githubusercontent.com/assets/1538216/19007187/69670bd8-8718-11e6-8f58-63415ab28dfb.png">

<img width="1424" alt="screen shot 2016-09-27 at 3 55 18 pm" src="https://cloud.githubusercontent.com/assets/1538216/19007195/7383375e-8718-11e6-8d0d-a2807d96ee29.png">

After:
<img width="1426" alt="screen shot 2016-09-30 at 2 18 00 pm" src="https://cloud.githubusercontent.com/assets/1538216/19007263/d52c4112-8718-11e6-9556-2c1e700b6ae3.png">

<img width="1430" alt="screen shot 2016-09-30 at 2 17 44 pm" src="https://cloud.githubusercontent.com/assets/1538216/19007273/ec81e1f0-8718-11e6-8dce-c651f964955b.png">
