### PR TITLE
Add unread notification indicator, clean up notifications

### DIFF
--- a/client/app/components/navigation/_navigation.sass
+++ b/client/app/components/navigation/_navigation.sass
@@ -8,6 +8,17 @@
     height: 20px
     margin-top: 10px
 
+  .nav .nav-item-iconic.indicator
+    width: 40px
+
+  .nav .nav-item-iconic .badge
+    position: relative
+    top: -23px
+    right : -10px
+    margin: 0px
+    min-width: 13px
+    background-color: #0088ce
+
 .navbar__user-name
   display: inline-block
   color: $color-white
@@ -22,3 +33,6 @@
     transform: rotate(45deg)
     content: '\f08d'
     display: inline-block
+
+.toast-notifications-list-pf
+  top: 65px

--- a/client/app/components/navigation/navigation-contoller.js
+++ b/client/app/components/navigation/navigation-contoller.js
@@ -187,6 +187,11 @@
     function refreshNotifications() {
       vm.notificationGroups = EventNotifications.state().groups;
       vm.newNotifications = EventNotifications.state().unreadNotifications;
+      vm.unreadNotificationCount = 0;
+      angular.forEach(vm.notificationGroups, function(group) {
+        vm.unreadNotificationCount += group.unreadCount;
+      });
+      vm.notificationsIndicatorTooltip = __(vm.unreadNotificationCount + " unread notifications");
     }
 
     function refreshToast() {
@@ -233,15 +238,17 @@
 
     function getNotficationStatusIconClass(notification) {
       var retClass = '';
-      if (notification && notification.data && notification.data.status) {
-        if (notification.data.status === 'info') {
+      if (notification && notification.type) {
+        if (notification.type === 'info') {
           retClass = "pficon pficon-info";
-        } else if (notification.data.status === 'error') {
+        } else if (notification.type === 'error') {
           retClass = "pficon pficon-error-circle-o";
-        } else if (notification.data.status === 'warning') {
+        } else if (notification.type === 'warning') {
           retClass = "pficon pficon-warning-triangle-o";
-        } else if (notification.data.status === 'success') {
+        } else if (notification.type === 'success') {
           retClass = "pficon pficon-ok";
+        } else {
+          retClass = "pficon pficon-info";  // default to info
         }
       }
 

--- a/client/app/components/notifications/_notifications.sass
+++ b/client/app/components/notifications/_notifications.sass
@@ -32,12 +32,11 @@
 
   .footer-button-left
     display: inline-block
-    width: calc(50% - 25px)
-    text-align: right
-    margin: 0 10px
+    text-align: left
+    margin-left: 30px
 
   .footer-button-right
     display: inline-block
-    width: calc(50% - 35px)
-    text-align: left
-    margin: 0 10px
+    float: right
+    text-align: right
+    margin-right: 30px

--- a/client/app/components/notifications/notification-footer.html
+++ b/client/app/components/notifications/notification-footer.html
@@ -16,7 +16,6 @@
        confirmation-on-ok="customScope.clearAllNotifications(notificationGroup)"
        confirmation-ok-style="primary"
        confirmation-show-cancel="true" >
-      <span class="pficon pficon-close"></span>
       <span>{{'Clear All' | translate}}</span>
     </a>
   </div>

--- a/client/app/config/navigation.config.js
+++ b/client/app/config/navigation.config.js
@@ -68,7 +68,7 @@
         administration: {
           title: N_('Administration'),
           state: 'administration',
-          iconClass: 'pficon pficon-settomgs',
+          iconClass: 'fa fa-cog',
           secondary: {
             profiles: {
               title: N_('Profiles'),

--- a/client/app/layouts/application.html
+++ b/client/app/layouts/application.html
@@ -21,14 +21,15 @@
       </ul>
       <ul class="nav navbar-nav navbar-right navbar-iconic">
         <li ng-if="vm.shoppingCart.allowed()">
-          <a title="{{'Shopping cart' | translate}}" class="nav-item-iconic" ng-click="vm.shoppingCart.open()">
+          <a title="{{'Shopping cart' | translate}}" class="nav-item-iconic indicator" ng-click="vm.shoppingCart.open()">
             <i class="fa fa-shopping-cart"></i>
             <span class="badge" ng-show="vm.shoppingCart.count" ng-bind="vm.shoppingCart.count"></span>
           </a>
         </li>
         <li>
-          <a title="{{'Toggle notifications list' | translate}}" class="nav-item-iconic" ng-click="vm.toggleNotificationsList()">
-            <span class="fa" ng-class="{'fa-bell': vm.newNotifications, 'fa-bell-o': !vm.newNotifications}"></span>
+          <a title="{{vm.notificationsIndicatorTooltip}}" class="nav-item-iconic indicator" ng-click="vm.toggleNotificationsList()">
+            <i class="fa" ng-class="{'fa-bell': vm.newNotifications, 'fa-bell-o': !vm.newNotifications}"></i>
+            <span class="badge" ng-show="vm.newNotifications">&#8226</span>
           </a>
         </li>
         <li class="dropdown">


### PR DESCRIPTION
- Adds unread notification indictor badge to the nav bar
- move indicator badges to top right and change color from red to blue
- Fix notification items icons
- Update visuals for notification drawer action buttons
- Move toast notification list to be below the nav bar
- Update administration section’s icon

Indicators and Toast Positioning:
![image](https://cloud.githubusercontent.com/assets/11633780/19045692/31d8c902-8968-11e6-9c08-3aeb1376dc6b.png)

Notification drawer items, Administration section icon:
![image](https://cloud.githubusercontent.com/assets/11633780/19045729/57d9363c-8968-11e6-8605-09695e63791a.png)

@serenamarie125 @beanh66 @chriskacerguis 