### PR TITLE
Translation fixes

### DIFF
--- a/client/app/components/blueprints/blueprints-list.html
+++ b/client/app/components/blueprints/blueprints-list.html
@@ -29,12 +29,20 @@
           <i ng-if="item.ui_properties.visibility.id == '900'" class="fa fa-globe fa-2"></i>
           <i ng-if="item.ui_properties.visibility.id == '800'" class="pficon pficon-private"></i>
           <i ng-if="item.ui_properties.visibility && item.ui_properties.visibility.id != '800' && item.ui_properties.visibility.id != '900'" class="pficon pficon-tenant"></i>
-          {{ ((item.ui_properties.visibility != null) ? item.ui_properties.visibility.name : "Unassigned")|translate }}
+          <span ng-if="item.ui_properties.visibility">
+            {{ item.ui_properties.visibility.name }}
+          </span>
+          <span ng-if="!item.ui_properties.visibility" translate>
+            Unassigned
+          </span>
         </span>
       </div>
       <div class="col-md-2">
-        <span id="catalogName_{{$index}}" class="no-wrap">
-          {{ (item.ui_properties.service_catalog ? item.ui_properties.service_catalog.name : "Unassigned")|translate }}
+        <span ng-if="item.ui_properties.service_catalog" id="catalogName_{{$index}}" class="no-wrap">
+          {{ item.ui_properties.service_catalog.name }}
+        </span>
+        <span ng-if="!item.ui_properties.service_catalog" id="catalogName_{{$index}}" class="no-wrap" translate>
+          Unassigned
         </span>
       </div>
       <div class="col-md-2">

--- a/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
+++ b/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
@@ -86,7 +86,7 @@
 
       function saveSuccess() {
         $modalInstance.close();
-        EventNotifications.success(__(sprintf("%s ownership was saved.", vm.service.name)));
+        EventNotifications.success(sprintf(__("%s ownership was saved."), vm.service.name));
         $state.go($state.current, {}, {reload: true});
       }
 

--- a/tests/blueprints/blueprints-list.directive.spec.js
+++ b/tests/blueprints/blueprints-list.directive.spec.js
@@ -53,7 +53,7 @@ describe('app.components.blueprints.BlueprintsListDirective', function() {
 
       expect(catName0.html()).to.eq("Amazon Operations");
       expect(catName1.html()).to.eq("OpenStack Operations");
-      expect(catName2.html()).to.eq("Unassigned");
+      expect(catName2.text()).to.eq("Unassigned");
     });
 
     it('should display the correct Visibility icons', function () {


### PR DESCRIPTION
Fixes:
* don't apply `translate` filter on a dynamic expression
* don't apply `__()` on a dynamic expression

In neither of those cases above would the string be collected by `gulp gettext-extract`.