### PR TITLE
[EUWE] Translation fixes euwe

### DIFF
--- a/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
+++ b/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
@@ -86,7 +86,7 @@
 
       function saveSuccess() {
         $modalInstance.close();
-        EventNotifications.success(__(sprintf("%s ownership was saved.", vm.service.name)));
+        EventNotifications.success(sprintf(__("%s ownership was saved."), vm.service.name));
         $state.go($state.current, {}, {reload: true});
       }
 

--- a/client/app/states/designer/blueprints/list/list.html
+++ b/client/app/states/designer/blueprints/list/list.html
@@ -29,12 +29,16 @@
           <i ng-if="item.visibility.id == '900'" class="fa fa-globe fa-2"></i>
           <i ng-if="item.visibility.id == '800'" class="pficon pficon-private"></i>
           <i ng-if="item.visibility && item.visibility.id != '800' && item.visibility.id != '900'" class="pficon pficon-tenant"></i>
-          {{ ((item.visibility != null) ? item.visibility.name : "Unassigned")|translate }}
+          <span ng-if="item.visibility">{{ item.visibility.name }}</span>
+          <span ng-if="!item.visibility" translate>Unassigned</span>
         </span>
       </div>
       <div class="col-md-2">
-        <span class="no-wrap">
-          {{ (item.content.service_catalog ? item.content.service_catalog.name : "Unassigned")|translate }}
+        <span ng-if="item.content.service_catalog" class="no-wrap">
+          {{ item.content.service_catalog.name }}
+        </span>
+        <span ng-if="!item.content.service_catalog" class="no-wrap" translate>
+          Unassigned
         </span>
       </div>
       <div class="col-md-2">


### PR DESCRIPTION
Fixes:
* don't apply `translate` filter on a dynamic expression
* don't apply `__()` on a dynamic expression

In neither of those cases above would the string be collected by `gulp gettext-extract`.

This is a variant of the fixes from PR #227 for euwe branch.