### PR TITLE
Restores eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,9 +12,9 @@
   "plugins": [
   ],
   "globals": {
-    "flowchart": true,  // Blueprints support lib
-    "__": true,  // Zanata parsing cue
-    "N_": true   // Zanata parsing cue
+    "flowchart": true, // Blueprints support lib
+    "__": true, // Zanata parsing cue
+    "N_": true // Zanata parsing cue
   },
   "rules": {
     "accessor-pairs": "error",
@@ -42,7 +42,7 @@
         "properties": "always"
       }
     ],
-//    "class-methods-use-this": "error",
+    "class-methods-use-this": "error",
     "comma-dangle": [
       "error",
       "always-multiline"
@@ -77,7 +77,7 @@
     "dot-notation": "error",
     "eol-last": "error",
     "eqeqeq": "error",
-//    "func-call-spacing": "error",
+    "func-call-spacing": "error",
     "func-names": "off",
     "func-style": "off",
     "generator-star-spacing": "error",
@@ -134,10 +134,10 @@
     "max-params": "off",
     "max-statements": "off",
     "max-statements-per-line": "off",
-//    "multiline-ternary": [
-//      "error",
-//      "never"
-//    ],
+    "multiline-ternary": [
+      "error",
+      "never"
+    ],
     "new-parens": "error",
     "newline-after-var": "off",
     "newline-before-return": "error",
@@ -160,7 +160,7 @@
     "no-extra-label": "error",
     "no-extra-parens": "off",
     "no-floating-decimal": "error",
-//    "no-global-assign": "error",
+    "no-global-assign": "error",
     "no-implicit-coercion": [
       "error",
       {
@@ -218,7 +218,7 @@
     "no-spaced-func": "error",
     "no-sync": "error",
     "no-tabs": "off",
-//    "no-template-curly-in-string": "error",
+    "no-template-curly-in-string": "error",
     "no-ternary": "off",
     "no-throw-literal": "error",
     "no-trailing-spaces": "off",
@@ -227,7 +227,7 @@
     "no-underscore-dangle": "off",
     "no-unmodified-loop-condition": "error",
     "no-unneeded-ternary": "error",
-//    "no-unsafe-negation": "error",
+    "no-unsafe-negation": "error",
     "no-unused-expressions": "off",
     "no-unused-vars": "off",
     "no-use-before-define": "off",
@@ -304,7 +304,7 @@
       "always"
     ],
     "strict": "off",
-//    "symbol-description": "error",
+    "symbol-description": "error",
     "template-curly-spacing": "error",
     "unicode-bom": [
       "error",


### PR DESCRIPTION
Good job team, no rules violated in between the eslint refactoring and now! 🙇‍♀️ 🙏 👏  

These rules were commented out to satisfy an older version of eslint.
Now that dependencies have been updated they can be restored.

@chriskacerguis 

closes #228 