### PR TITLE
Add a new view service dialog list to SUI

### DIFF
--- a/client/app/components/_components.sass
+++ b/client/app/components/_components.sass
@@ -3,6 +3,7 @@
 // @import all of your component styles here
 
 @import 'dialog-content/dialog-content'
+@import 'dialogs/dialogs'
 @import 'navigation/navigation'
 @import 'notifications/notifications'
 @import 'ss-card/ss-card'

--- a/client/app/components/dialogs/_dialogs.sass
+++ b/client/app/components/dialogs/_dialogs.sass
@@ -1,0 +1,9 @@
+.dialogs-list
+
+  .list-view-pf
+    padding-bottom: 68px
+
+    .list-group-item
+      padding-bottom: 20px
+      padding-top: 20px
+      line-height: 1.66666667

--- a/client/app/components/dialogs/dialogs-list.directive.js
+++ b/client/app/components/dialogs/dialogs-list.directive.js
@@ -1,0 +1,124 @@
+/* eslint camelcase: "off" */
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+      .directive('dialogsList', function() {
+        return {
+          restrict: 'AE',
+          templateUrl: "app/components/dialogs/dialogs-list.html",
+          scope: {
+            dialogs: "=",
+          },
+          controller: DialogListController,
+          controllerAs: 'vm',
+          bindToController: true,
+        };
+      });
+
+  /** @ngInject */
+  function DialogListController($state, DialogsState, EventNotifications, $rootScope, $filter, Language, ListView) {
+    var vm = this;
+
+    vm.title = __('Dialogs List');
+
+    vm.dialogList = angular.copy(vm.dialogs);
+
+    vm.listConfig = {
+      selectItems: false,
+      showSelectBox: false,
+    };
+
+    vm.toolbarConfig = {
+      filterConfig: {
+        fields: [
+          {
+            id: 'label',
+            title: __('Dialog Name'),
+            placeholder: __('Filter by Name'),
+            filterType: 'text',
+          },
+          {
+            id: 'updated_at',
+            title: __('Last Updated'),
+            placeholder: __('Filter by Last Updated'),
+            filterType: 'text',
+          },
+        ],
+        resultsCount: vm.dialogList.length,
+        appliedFilters: DialogsState.getFilters(),
+        onFilterChange: filterChange,
+      },
+      sortConfig: {
+        fields: getSortConfigFields(),
+        onSortChange: sortChange,
+        isAscending: DialogsState.getSort().isAscending,
+        currentField: DialogsState.getSort().currentField,
+      },
+      actionsConfig: {
+        primaryActions: [ ],
+      },
+    };
+
+    function getSortConfigFields() {
+      return [
+        {
+          id: 'label',
+          title: __('Dialog Name'),
+          sortType: 'alpha',
+        },
+        {
+          id: 'updated_at',
+          title: __('Last Updated'),
+          sortType: 'numeric',
+        },
+      ];
+    }
+
+    /* Apply the filtering to the data list */
+    filterChange(DialogsState.getFilters());
+
+    function sortChange(sortId, isAscending) {
+      vm.dialogList.sort(compareFn);
+
+      /* Keep track of the current sorting state */
+      DialogsState.setSort(sortId, vm.toolbarConfig.sortConfig.isAscending);
+    }
+
+    function compareFn(item1, item2) {
+      var compValue = 0;
+      if (vm.toolbarConfig.sortConfig.currentField.id === 'label') {
+        compValue = item1.label.localeCompare(item2.label);
+      } else if (vm.toolbarConfig.sortConfig.currentField.id === 'updated_at') {
+        compValue = new Date(item1.updated_at) - new Date(item2.updated_at);
+      }
+
+      if (!vm.toolbarConfig.sortConfig.isAscending) {
+        compValue = compValue * -1;
+      }
+
+      return compValue;
+    }
+
+    function filterChange(filters) {
+      vm.dialogList = ListView.applyFilters(filters, vm.dialogList, vm.dialogs, DialogsState, matchesFilter);
+
+      /* Make sure sorting direction is maintained */
+      sortChange(DialogsState.getSort().currentField, DialogsState.getSort().isAscending);
+
+      vm.toolbarConfig.filterConfig.resultsCount = vm.dialogList.length;
+    }
+
+    var matchesFilter = function (item, filter) {
+      if (filter.id === 'label') {
+        return item.label.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
+      } else if (filter.id === 'updated_at') {
+        return $filter('date')(item.updated_at, 'yyyy-MM-dd hh:mm a').toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
+      }
+
+      return false;
+    };
+
+    Language.fixState(DialogsState, vm.toolbarConfig);
+  }
+})();

--- a/client/app/components/dialogs/dialogs-list.html
+++ b/client/app/components/dialogs/dialogs-list.html
@@ -1,0 +1,34 @@
+<div pf-toolbar id="dialogsToolbar" config="vm.toolbarConfig"></div>
+
+<div class="list-view-container">
+  <div pf-list-view id="dialogList" class="dialogs-list" config="vm.listConfig" items="vm.dialogList"
+       action-buttons="vm.actionButtons"
+       enable-button-for-item-fn="vm.enableButtonForItemFn"
+       menu-actions="vm.menuActions"
+       update-menu-action-for-item-fn="vm.updateMenuActionForItemFn">
+    <div class="row">
+      <div class="col-md-4">
+        <span class="no-wrap">
+          {{ item.label }}
+        </span>
+      </div>
+      <div class="col-md-3">
+        <span class="no-wrap">
+          <strong translate>Last Updated</strong>&nbsp;{{ item.updated_at | date:'yyyy-MM-dd hh:mm a' }}
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  $(function() {
+    setTimeout(function(){
+      $(".simple-filter .dropdown-menu li a").click(function(){
+        $(".simple-filter input").focus();
+      });
+      $("#dialogList .list-view-pf .list-group-item .list-view-pf-actions .btn-default").addClass("btn-primary");
+    }, 500);
+  });
+</script>
+
+

--- a/client/app/config/navigation.config.js
+++ b/client/app/config/navigation.config.js
@@ -62,6 +62,16 @@
                   tooltip: N_('The total number of available blueprints'),
                 },
               ],
+            }, 
+            dialogs: {
+              title: N_('Dialogs'),
+              state: 'designer.dialogs',
+              badges: [
+                {
+                  count: 0,
+                  tooltip: N_('The total number of available dialogs'),
+                },
+              ],
             },
           },
         },
@@ -104,6 +114,7 @@
     NavCounts.add('requests', fetchRequests, refreshTimeMs);
     NavCounts.add('marketplace', fetchServiceTemplates, refreshTimeMs);
     NavCounts.add('blueprints', fetchBlueprints, refreshTimeMs);
+    NavCounts.add('dialogs', fetchDialogs, refreshTimeMs);
     NavCounts.add('profiles', fetchProfiles, refreshTimeMs);
     NavCounts.add('rules', fetchRules, refreshTimeMs);
 
@@ -149,6 +160,17 @@
 
       CollectionsApi.query('blueprints', options)
         .then(lodash.partial(updateDesignerSecondaryCount, 'blueprints'));
+    }
+
+    function fetchDialogs() {
+      var options = {
+        expand: false,
+        filter: ['id>0'],
+        auto_refresh: true,
+      };
+
+      CollectionsApi.query('service_dialogs', options)
+        .then(lodash.partial(updateDesignerSecondaryCount, 'dialogs'));
     }
 
     function fetchProfiles() {

--- a/client/app/services/dialogs-state.service.js
+++ b/client/app/services/dialogs-state.service.js
@@ -1,0 +1,17 @@
+/* eslint camelcase: "off" */
+/* eslint no-cond-assign: "off" */
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('DialogsState', DialogStateFactory);
+
+  /** @ngInject */
+  function DialogStateFactory(ListConfiguration) {
+    var dialog = {};
+
+    ListConfiguration.setupListFunctions(dialog, {id: 'label', title: __('Name'), sortType: 'alpha'});
+    
+    return dialog;
+  }
+})();

--- a/client/app/services/list-configuration.service.js
+++ b/client/app/services/list-configuration.service.js
@@ -1,0 +1,40 @@
+/* eslint camelcase: "off" */
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('ListConfiguration', ListConfigurationFactory);
+
+  /** @ngInject */
+  function ListConfigurationFactory() {
+    var configuration = {};
+
+    configuration.setupListFunctions = function(list, currentField) {
+      list.sort = {
+        isAscending: true,
+        currentField: currentField,
+      };
+
+      list.filters = [];
+
+      list.setSort = function (currentField, isAscending) {
+        list.sort.isAscending = isAscending;
+        list.sort.currentField = currentField;
+      };
+
+      list.getSort = function () {
+        return list.sort;
+      };
+
+      list.setFilters = function (filterArray) {
+        list.filters = filterArray;
+      };
+
+      list.getFilters = function () {
+        return list.filters;
+      };
+    };
+
+    return configuration;
+  }
+})();

--- a/client/app/services/marketplace-state.service.js
+++ b/client/app/services/marketplace-state.service.js
@@ -5,32 +5,10 @@
     .factory('MarketplaceState', MarketplaceStateFactory);
 
   /** @ngInject */
-  function MarketplaceStateFactory() {
+  function MarketplaceStateFactory(ListConfiguration) {
     var service = {};
 
-    service.sort = {
-      isAscending: true,
-      currentField: { id: 'name', title: __('Name'), sortType: 'alpha' },
-    };
-
-    service.filters = [];
-
-    service.setSort = function(currentField, isAscending) {
-      service.sort.isAscending = isAscending;
-      service.sort.currentField = currentField;
-    };
-
-    service.getSort = function() {
-      return service.sort;
-    };
-
-    service.setFilters = function(filterArray) {
-      service.filters = filterArray;
-    };
-
-    service.getFilters = function() {
-      return service.filters;
-    };
+    ListConfiguration.setupListFunctions(service, { id: 'name', title: __('Name'), sortType: 'alpha' });
 
     return service;
   }

--- a/client/app/services/orders-state.service.js
+++ b/client/app/services/orders-state.service.js
@@ -5,32 +5,10 @@
     .factory('OrdersState', OrdersStateFactory);
 
   /** @ngInject */
-  function OrdersStateFactory() {
+  function OrdersStateFactory(ListConfiguration) {
     var service = {};
 
-    service.sort = {
-      isAscending: false,
-      currentField: { id: 'placed_at', title: __('Order Date'), sortType: 'numeric' },
-    };
-
-    service.filters = [];
-
-    service.setSort = function(currentField, isAscending) {
-      service.sort.isAscending = isAscending;
-      service.sort.currentField = currentField;
-    };
-
-    service.getSort = function() {
-      return service.sort;
-    };
-
-    service.setFilters = function(filterArray) {
-      service.filters = filterArray;
-    };
-
-    service.getFilters = function() {
-      return service.filters;
-    };
+    ListConfiguration.setupListFunctions(service, { id: 'placed_at', title: __('Order Date'), sortType: 'numeric' });
 
     return service;
   }

--- a/client/app/services/requests-state.service.js
+++ b/client/app/services/requests-state.service.js
@@ -5,32 +5,10 @@
     .factory('RequestsState', RequestsStateFactory);
 
   /** @ngInject */
-  function RequestsStateFactory() {
+  function RequestsStateFactory(ListConfiguration) {
     var service = {};
 
-    service.sort = {
-      isAscending: false,
-      currentField: { id: 'requested', title: __('Request Date'), sortType: 'numeric' },
-    };
-
-    service.filters = [];
-
-    service.setSort = function(currentField, isAscending) {
-      service.sort.isAscending = isAscending;
-      service.sort.currentField = currentField;
-    };
-
-    service.getSort = function() {
-      return service.sort;
-    };
-
-    service.setFilters = function(filterArray) {
-      service.filters = filterArray;
-    };
-
-    service.getFilters = function() {
-      return service.filters;
-    };
+    ListConfiguration.setupListFunctions(service, { id: 'requested', title: __('Request Date'), sortType: 'numeric' });
 
     return service;
   }

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -6,32 +6,10 @@
     .factory('ServicesState', ServicesStateFactory);
 
   /** @ngInject */
-  function ServicesStateFactory() {
+  function ServicesStateFactory(ListConfiguration) {
     var service = {};
 
-    service.sort = {
-      isAscending: true,
-      currentField: { id: 'name', title: __('Name'), sortType: 'alpha' },
-    };
-
-    service.filters = [];
-
-    service.setSort = function(currentField, isAscending) {
-      service.sort.isAscending = isAscending;
-      service.sort.currentField = currentField;
-    };
-
-    service.getSort = function() {
-      return service.sort;
-    };
-
-    service.setFilters = function(filterArray) {
-      service.filters = filterArray;
-    };
-
-    service.getFilters = function() {
-      return service.filters;
-    };
+    ListConfiguration.setupListFunctions(service, { id: 'name', title: __('Name'), sortType: 'alpha' });
 
     return service;
   }

--- a/client/app/states/designer/blueprints/blueprints.state.js
+++ b/client/app/states/designer/blueprints/blueprints.state.js
@@ -13,7 +13,7 @@
     return {
       'designer.blueprints': {
         parent: 'application',
-        url: '/designer/blueprints',
+        url: '/blueprints',
         redirectTo: 'designer.blueprints.list',
         template: '<ui-view></ui-view>',
       },

--- a/client/app/states/designer/dialogs/dialogs.state.js
+++ b/client/app/states/designer/dialogs/dialogs.state.js
@@ -11,10 +11,11 @@
 
   function getStates() {
     return {
-      'designer': {
+      'designer.dialogs': {
         parent: 'application',
-        url: '/designer',
-        redirectTo: 'designer.blueprints',
+        url: '/dialogs',
+        redirectTo: 'designer.dialogs.list',
+        template: '<ui-view></ui-view>',
       },
     };
   }

--- a/client/app/states/designer/dialogs/list/list.html
+++ b/client/app/states/designer/dialogs/list/list.html
@@ -1,0 +1,1 @@
+<dialogs-list dialogs="vm.dialogs" />

--- a/client/app/states/designer/dialogs/list/list.state.js
+++ b/client/app/states/designer/dialogs/list/list.state.js
@@ -1,0 +1,43 @@
+/* eslint camelcase: "off" */
+(function() {
+  'use strict';
+
+  angular.module('app.states')
+    .run(appRun);
+
+  /** @ngInject */
+  function appRun(routerHelper) {
+    routerHelper.configureStates(getStates());
+  }
+
+  function getStates() {
+    return {
+      'designer.dialogs.list': {
+        url: '', // No url, this state is the index of dialogs
+        templateUrl: 'app/states/designer/dialogs/list/list.html',
+        controller: DialogsController,
+        controllerAs: 'vm',
+        title: N_('Dialog List'),
+        resolve: {
+          dialogs: resolveDialogs,
+        },
+      },
+    };
+  }
+
+  /** @ngInject */
+  function resolveDialogs(CollectionsApi) {
+    var options = {
+      expand: 'resources',
+      attributes: 'bundle',
+    };
+
+    return CollectionsApi.query('service_dialogs', options);
+  }
+
+  /** @ngInject */
+  function DialogsController(dialogs) {
+    var vm = this;
+    vm.dialogs = dialogs.resources;
+  }
+})();

--- a/tests/dialogs-list.state.spec.js
+++ b/tests/dialogs-list.state.spec.js
@@ -1,0 +1,39 @@
+describe('Dialogs', function() {
+  beforeEach(function() {
+    module('app.states', 'app.config', 'gettext', bard.fakeToastr);
+    bard.inject('$location', '$rootScope', '$state', '$templateCache', 'Session');
+  });
+
+  describe('route', function() {
+    beforeEach(function() {
+      bard.inject('$location', '$rootScope', '$state', '$templateCache');
+    });
+
+    it('should work with $state.go', function() {
+      $state.go('designer.dialogs.list');
+      $rootScope.$apply();
+      expect($state.is('designer.dialogs.list'));
+    });
+  });
+
+  describe('controller', function() {
+    var controller;
+    var dialogs = {
+      name: 'services_dialogs',
+      count: 1,
+      subcount: 1,
+      resources: []
+    };
+
+    beforeEach(function() {
+      bard.inject('$controller', '$log', '$state', '$rootScope');
+
+      controller = $controller($state.get('designer.dialogs.list').controller, {dialogs: dialogs});
+      $rootScope.$apply();
+    });
+
+    it('should be created successfully', function() {
+      expect(controller).to.be.defined;
+    });
+  });
+});

--- a/tests/dialogs/dialogs-list.directive.spec.js
+++ b/tests/dialogs/dialogs-list.directive.spec.js
@@ -1,0 +1,86 @@
+describe('app.components.DialogsListDirective', function() {
+  var $scope;
+  var $compile;
+  var element;
+
+  beforeEach(function () {
+    module('app.services', 'app.config', 'app.states', 'app.components', 'gettext');
+    bard.inject('DialogsState', '$state', 'Session', '$httpBackend', '$timeout');
+  });
+
+  beforeEach(inject(function (_$compile_, _$rootScope_, _$document_) {
+    $compile = _$compile_;
+    $scope = _$rootScope_;
+    $document = _$document_;
+  }));
+
+  var compileHTML = function (markup, scope) {
+    element = angular.element(markup);
+    $compile(element)(scope);
+
+    scope.$digest();
+  };
+
+  beforeEach(function () {
+    Session.create({
+      auth_token: 'b10ee568ac7b5d4efbc09a6b62cb99b8',
+    });
+    $httpBackend.whenGET('').respond(200);
+
+    $scope.dialogs = [
+      {
+        "updated_at": "2001-03-28T23:19:35Z",
+        "label": "azure-single-vm-from-user-image",
+      },
+      {
+        "updated_at": "2016-07-27T23:29:25Z",
+        "label": "Hybrid Cloud Application",
+      },
+      {
+        "updated_at": "2016-08-23T22:57:46Z",
+        "label": "Create VM (RHEV)",
+      },
+      {
+        "updated_at": "2000-02-20T00:01:27Z",
+        "label": "RHEL7 with PostgreSQL",
+      },
+      {
+        "updated_at": "2016-09-23T22:58:00Z",
+        "label": "Create VM (VMware)",
+      },
+      {
+        "updated_at": "2016-08-23T23:10:54Z",
+        "label": "Create VM (EC2)",
+      },
+    ];
+
+    var htmlTmp = '<dialogs-list dialogs="dialogs"></dialogs-list>';
+
+    compileHTML(htmlTmp, $scope);
+  });
+
+  describe('dialogList', function() {
+    it('should have correct number of rows', function () {
+      var rows = element.find('#dialogList .list-group-item');
+      expect(rows.length).to.eq($scope.dialogs.length);
+    });
+
+    it('should sort the dialogs appropriately', function () {
+      // Default sort is by name
+      var nameSpans = element.find('.list-view-pf-main-info > .row > .col-md-4 > span');
+      expect(nameSpans.length).to.eq(6);
+      expect(nameSpans[0].innerHTML).to.eq("azure-single-vm-from-user-image");
+
+      var sortItems = element.find('.sort-pf .sort-field');
+      expect(sortItems.length).to.eq(2);
+
+      // Sort by date updated
+      eventFire(angular.element(sortItems[1]), 'click');
+      $scope.$digest();
+
+      nameSpans = element.find('.list-view-pf-main-info > .row > .col-md-4 > span');
+      expect(nameSpans.length).to.eq(6);
+      expect(nameSpans[0].innerHTML).to.eq('RHEL7 with PostgreSQL');
+    });
+  });
+});


### PR DESCRIPTION
This adds a new menu option for dialogs under the designer section (along with blueprints).  The page only consists of a list with filter by name/last updated and sorting by the same two columns.

New unit tests for the list view state, loading and sorting were also added. 

The other major change is from code climate errors when run locally.  The state services in the simpler states consist of boilerplate code that is repeated regularly (for setting up filtering and sorting functions).  This was pulled out into a list configuration service that shares the code now.  Code climate did not report any errors on the services folder after this.
@chriskacerguis @serenamarie125 @dclarizio 

<img width="1153" alt="screen shot 2016-10-08 at 7 11 23 am" src="https://cloud.githubusercontent.com/assets/7306953/19212786/d9ff4130-8d26-11e6-9d9a-22292f85e1ad.png">
![designer-dialogs](https://cloud.githubusercontent.com/assets/7306953/19212789/df21b062-8d26-11e6-94c2-c5f0bf0f9ff1.png)
