### PR TITLE
Fix for Bugzilla 1383367: Overlapping Help and User menus

### DIFF
--- a/client/app/components/navigation/navigation-contoller.js
+++ b/client/app/components/navigation/navigation-contoller.js
@@ -13,6 +13,7 @@
     '$scope',
     '$modal',
     '$state',
+    '$document',
     'EventNotifications',
     'ServerInfo',
     'ProductInfo',
@@ -28,6 +29,7 @@
                           $scope,
                           $modal,
                           $state,
+                          $document,
                           EventNotifications,
                           ServerInfo,
                           ProductInfo) {
@@ -107,6 +109,7 @@
 
     vm.notificationsDrawerShown = false;
     vm.toggleNotificationsList = toggleNotificationsList;
+    vm.closeOtherDropdowns = closeOtherDropdowns;
     vm.newNotifications = false;
     vm.getNotficationStatusIconClass = getNotficationStatusIconClass;
     vm.markNotificationRead = markNotificationRead;
@@ -234,6 +237,12 @@
 
     function toggleNotificationsList() {
       vm.notificationsDrawerShown = !vm.notificationsDrawerShown;
+    }
+
+    function closeOtherDropdowns() {
+      var userDropdown = angular.element( $document[0].getElementById('userDropdown') );
+      userDropdown.removeClass('open');
+      userDropdown.children().attr('aria-expanded', false);
     }
 
     function getNotficationStatusIconClass(notification) {

--- a/client/app/layouts/application.html
+++ b/client/app/layouts/application.html
@@ -33,7 +33,8 @@
           </a>
         </li>
         <li class="dropdown">
-          <a class="dropdown-toggle nav-item-iconic" id="aboutModal" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          <a class="dropdown-toggle nav-item-iconic" id="aboutModal" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true"
+            ng-click="vm.closeOtherDropdowns()">
             <span class="fa pficon-help"></span>
             <span class="caret"></span>
           </a>
@@ -55,7 +56,7 @@
             </li>
           </ul>
         </li>
-        <li dropdown>
+        <li dropdown id="userDropdown">
           <a dropdown-toggle class="nav-item-iconic" title="{{ ::vm.user().userid }}">
             <i class="fa pficon-user"></i>
             <p class="navbar__user-name">{{ ::vm.user().name }}</p>


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/12733153/19242076/a3b7fc6a-8edf-11e6-9830-ddbeb287e520.png)

After:

![image](https://cloud.githubusercontent.com/assets/12733153/19242105/bc539298-8edf-11e6-8495-11419e535ea5.png)

* Opening Help dropdown menu closes User dropdown menu.

Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1383367

