### PR TITLE
Hide role change priority buttons when not applicable

### DIFF
--- a/client/app/components/rules/_rules.sass
+++ b/client/app/components/rules/_rules.sass
@@ -24,6 +24,9 @@
       .priority-button
         visibility: visible
         pointer-events: all
+        &.invisible
+          opacity: 0
+          pointer-events: none
       .priority-button[disabled]
         visibility: hidden
 

--- a/client/app/components/rules/rules-list.html
+++ b/client/app/components/rules/rules-list.html
@@ -102,12 +102,12 @@
                 <div class="btn-container">
                   <button class="btn btn-link priority-button" type=button"
                           ng-click="vm.downPriority(item)"
-                          ng-disabled="vm.editMode">
+                          ng-disabled="vm.editMode" ng-class="{invisible: $index >= vm.arbitrationRules.length - 1}">
                     <span class="fa fa-arrow-down"></span>
                   </button>
                   <button class="btn btn-link priority-button" type=button"
                           ng-click="vm.upPriority(item)"
-                          ng-disabled="vm.editMode">
+                          ng-disabled="vm.editMode" ng-class="{invisible: $index <= 0}">
                     <span class="fa fa-arrow-up"></span>
                   </button>
                 </div>


### PR DESCRIPTION
Hide the arrow buttons that allow the user to change priorities of a rule when they are not applicable. That is, the first row cannot be moved up and the last row cannot be moved down.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1381705

@miq-bot add-label euwe/yes