### PR TITLE
Fix the bytes displayed for Memory in the Service Detail page

### DIFF
--- a/client/app/filters/format-bytes.filter.js
+++ b/client/app/filters/format-bytes.filter.js
@@ -15,4 +15,10 @@
       return (val.match(/\.0*$/) ? val.substr(0, val.indexOf('.')) : val) + ' ' + availableUnits[unit];
     };
   });
+
+  angular.module('app.services').filter('megaBytes', function() {
+    return function(bytes) {
+      return bytes * 1024 * 1024;
+    };
+  });
 })();

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -118,7 +118,7 @@
                 <div class="form-group">
                   <label class="control-label col-sm-4" translate>Memory</label>
                   <div class="col-sm-8">
-                    <input class="form-control" disabled value="{{ ::vm.service.aggregate_all_vm_memory | formatBytes }}"/>
+                    <input class="form-control" disabled value="{{ ::vm.service.aggregate_all_vm_memory | megaBytes | formatBytes }}"/>
                   </div>
                 </div>
                 <div class="form-group">


### PR DESCRIPTION
The `aggregate_all_vm_memory` returned for a service is a number that represents Megabytes.

A new filter called `megaBytes` was created which was then applied to the `aggregate_all_vm_memory` value to get the correct byte value.

Note that the OPS UI uses Rails `.megabytes` method to convert a byte value to megabytes as shown here:
https://github.com/ManageIQ/manageiq/blob/master/app/helpers/service_helper/textual_summary.rb#L43

Before:
<img width="1153" alt="screen shot 2016-10-11 at 4 40 24 pm" src="https://cloud.githubusercontent.com/assets/1538216/19292522/8895327a-8fd1-11e6-85af-257f9605c446.png">

After:
<img width="1153" alt="screen shot 2016-10-11 at 4 38 14 pm" src="https://cloud.githubusercontent.com/assets/1538216/19292529/8f8a06a0-8fd1-11e6-9f82-7913b45138f2.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1383335